### PR TITLE
fix: sort product list server-side using the api #44

### DIFF
--- a/src/UI/Buyer/src/app/products/containers/product-list/product-list.component.html
+++ b/src/UI/Buyer/src/app/products/containers/product-list/product-list.component.html
@@ -49,8 +49,8 @@
                     formControlName="sortBy"
                     (change)="sortStratChanged()">
               <option [ngValue]="null" disabled>None</option>
-              <option [ngValue]="sortOption" *ngFor="let sortOption of sortOptions">
-                {{ sortOption }}
+              <option [ngValue]="sortOption.key" *ngFor="let sortOption of sortOptions | mapToIterable">
+                {{ sortOption.value }}
               </option>
             </select>
           </div>

--- a/src/UI/Buyer/src/app/products/containers/product-list/product-list.component.spec.ts
+++ b/src/UI/Buyer/src/app/products/containers/product-list/product-list.component.spec.ts
@@ -17,6 +17,7 @@ import { TreeModule } from 'angular-tree-component';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { ToggleFavoriteComponent } from '@app/shared/components/toggle-favorite/toggle-favorite.component';
 import { ProductCardComponent } from '@app/shared/components/product-card/product-card.component';
+import { MapToIterablePipe } from '@app/shared/pipes/map-to-iterable/map-to-iterable.pipe';
 
 describe('ProductListComponent', () => {
   const mockProductData = of({ Items: [], Meta: {} });
@@ -44,7 +45,8 @@ describe('ProductListComponent', () => {
         ProductCardComponent,
         QuantityInputComponent,
         CategoryNavComponent,
-        ToggleFavoriteComponent
+        ToggleFavoriteComponent,
+        MapToIterablePipe
       ],
       imports: [
         NgbPaginationModule,
@@ -137,12 +139,26 @@ describe('ProductListComponent', () => {
     });
   });
 
-  describe('toProductDetails', () => {
-    const product = { ID: 'mockProductID' };
-    it('should navigate to product detail with product.ID as ID query param', () => {
+  describe('sortStratChanged', () => {
+    it('should reload state with no search', () => {
       const navigateSpy = spyOn((<any>component).router, 'navigate');
-      component.toProductDetails(product);
-      expect(navigateSpy).toHaveBeenCalledWith(['/products/detail'], { queryParams: { ID: product.ID } });
+      const newSort = '!Name';
+      component.sortForm.controls['sortBy'].setValue(newSort);
+      component.sortStratChanged();
+      const newQueryParams = Object.assign({}, mockQueryParams, { sortBy: newSort });
+      expect(navigateSpy).toHaveBeenCalledWith([], { queryParams: newQueryParams });
+    });
+  });
+
+  describe('isProductFav', () => {
+    beforeEach(() => {
+      component.favoriteProducts = ['a', 'b', 'c'];
+    });
+    it('should return true for a favorite', () => {
+      expect(component.isProductFav({ ID: 'a' })).toEqual(true);
+    });
+    it('should return false for a non-favorite', () => {
+      expect(component.isProductFav({ ID: 'd' })).toEqual(false);
     });
   });
 
@@ -156,18 +172,6 @@ describe('ProductListComponent', () => {
       component.favoriteProducts = ['a', 'b'];
       component.setProductAsFav(true, 'c');
       expect(meService.Patch).toHaveBeenCalledWith({ xp: { FavoriteProducts: ['a', 'b', 'c'] } });
-    });
-  });
-
-  describe('isProductFav', () => {
-    beforeEach(() => {
-      component.favoriteProducts = ['a', 'b', 'c'];
-    });
-    it('should reutrn true for a favorite', () => {
-      expect(component.isProductFav({ ID: 'a' })).toEqual(true);
-    });
-    it('should reutrn false for a non-favorite', () => {
-      expect(component.isProductFav({ ID: 'd' })).toEqual(false);
     });
   });
 
@@ -189,6 +193,15 @@ describe('ProductListComponent', () => {
     });
   });
 
+  describe('toProductDetails', () => {
+    const product = { ID: 'mockProductID' };
+    it('should navigate to product detail with product.ID as ID query param', () => {
+      const navigateSpy = spyOn((<any>component).router, 'navigate');
+      component.toProductDetails(product);
+      expect(navigateSpy).toHaveBeenCalledWith(['/products/detail'], { queryParams: { ID: product.ID } });
+    });
+  });
+
   describe('addToCart', () => {
     const mockEvent = { product: { ID: 'MockProduct' }, quantity: 3 };
     beforeEach(() => {
@@ -198,5 +211,4 @@ describe('ProductListComponent', () => {
       expect(ocLineItemService.create).toHaveBeenCalledWith(mockEvent.product, mockEvent.quantity);
     });
   });
-
 });

--- a/src/UI/Buyer/src/app/products/models/product-sort-strats.enum.ts
+++ b/src/UI/Buyer/src/app/products/models/product-sort-strats.enum.ts
@@ -1,7 +1,6 @@
 export enum ProductSortStrats {
-    ID = 'ID',
-    NameAsc = 'Name: A to Z',
-    NameDesc = 'Name: Z to A',
-    PriceAsc = 'Price: Highest to Lowest',
-    PriceDesc = 'Price: Lowest to Highest'
+    ['ID'] = 'ID: A to Z',
+    ['!ID'] = 'ID: Z to A',
+    ['Name'] = 'Name: A to Z',
+    ['!Name'] = 'Name: Z to A',
 }

--- a/src/UI/Buyer/src/app/shared/pipes/map-to-iterable/map-to-iterable.pipe.ts
+++ b/src/UI/Buyer/src/app/shared/pipes/map-to-iterable/map-to-iterable.pipe.ts
@@ -1,0 +1,22 @@
+
+import { Pipe, PipeTransform } from '@angular/core';
+
+/**
+ * looping over a map doesn't work natively - https://stackoverflow.com/questions/31490713/iterate-over-object-in-angular
+ * this lets us loop over a map and retrieve values from 'value' and keys from 'key'
+ */
+@Pipe({
+    name: 'mapToIterable',
+    pure: false
+})
+export class MapToIterablePipe implements PipeTransform {
+    transform(map: any): any {
+        if (map === null || map === undefined) { return null; }
+        return Object.keys(map).map(key => {
+            return {
+                key: key,
+                value: map[key]
+            };
+        });
+    }
+}

--- a/src/UI/Buyer/src/app/shared/shared.module.ts
+++ b/src/UI/Buyer/src/app/shared/shared.module.ts
@@ -64,6 +64,7 @@ import { QuantityInputComponent } from './components/quantity-input/quantity-inp
 import { ToggleFavoriteComponent } from './components/toggle-favorite/toggle-favorite.component';
 import { ProductCardComponent } from './components/product-card/product-card.component';
 import { ProductCarouselComponent } from './components/product-carousel/product-carousel.component';
+import { MapToIterablePipe } from '@app/shared/pipes/map-to-iterable/map-to-iterable.pipe';
 
 @NgModule({
   imports: [
@@ -116,6 +117,7 @@ import { ProductCarouselComponent } from './components/product-carousel/product-
     PhoneFormatPipe,
     OrderStatusDisplayPipe,
     PaymentMethodDisplayPipe,
+    MapToIterablePipe,
     CreditCardIconComponent,
     AddressDisplayComponent,
     CreditCardDisplayComponent,
@@ -136,6 +138,7 @@ import { ProductCarouselComponent } from './components/product-carousel/product-
     PhoneFormatPipe,
     OrderStatusDisplayPipe,
     PaymentMethodDisplayPipe,
+    MapToIterablePipe,
     PageTitleComponent,
     AddressDisplayComponent,
     CreditCardDisplayComponent,
@@ -177,6 +180,7 @@ export class SharedModule {
         PhoneFormatPipe,
         OrderStatusDisplayPipe,
         PaymentMethodDisplayPipe,
+        MapToIterablePipe,
         AppErrorHandler,
         HasTokenGuard,
         IsLoggedInGuard,


### PR DESCRIPTION
Previously the sorting on product list was being done client-side for the current page of products. This will now sort products server-side so it sorts across all products in an org that a user is assigned to

Sorting by price will *not* be possible without some kind of data warehouse solution as it is not supported by our current search API due to complex pricing rules (one user may see a product at a different price then another)

Fixes #44

## Type of change: Bug Fix

- [ x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x ] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x] I have added tests that prove my fix is effective or that my feature works
- [x ] New and existing unit tests pass locally with my changes
- [x ] I have updated the acceptance criteria on the task so that it can be tested