### PR TITLE
fix: shipments tab not loading #39

### DIFF
--- a/src/UI/Buyer/src/app/order/containers/order-shipments/order-shipments.component.html
+++ b/src/UI/Buyer/src/app/order/containers/order-shipments/order-shipments.component.html
@@ -47,7 +47,7 @@
             <tbody>
               <tr *ngFor="let item of shipmentItems.Items">
                 <td>{{item.QuantityShipped + ' of ' + item.LineItem.Quantity}}</td>
-                <td>{{item.LineItem.xp.product.name}} <small class="text-muted">{{item.LineItem.xp.product.id}}</small></td>
+                <td>{{item.LineItem.Product.Name}} <small class="text-muted">{{item.LineItem.Product.ID}}</small></td>
               </tr>
             </tbody>
           </table>

--- a/src/UI/Buyer/src/app/order/containers/order-shipments/order-shipments.component.spec.ts
+++ b/src/UI/Buyer/src/app/order/containers/order-shipments/order-shipments.component.spec.ts
@@ -18,8 +18,8 @@ describe('OrderShipmentsComponent', () => {
   const shipmentsResolve = { Items: [{ ID: 'ShipmentOne' }] };
   const lineItemListResolve = {
     Items: [
-      { ID: 'LineItemOne', xp: { product: {} } },
-      { ID: 'LineItemTwo', xp: { product: {} } },
+      { ID: 'LineItemOne', Product: {} },
+      { ID: 'LineItemTwo', Product: {} },
     ],
   };
   const shipmentItems = {
@@ -118,11 +118,11 @@ describe('OrderShipmentsComponent', () => {
       const modifiedShipmentItems = component['setLineItem'](shipmentItems);
       expect(modifiedShipmentItems.Items[0]['LineItem']).toEqual({
         ID: 'LineItemTwo',
-        xp: { product: {} },
+        Product: {},
       });
       expect(modifiedShipmentItems.Items[1]['LineItem']).toEqual({
         ID: 'LineItemOne',
-        xp: { product: {} },
+        Product: {},
       });
     });
   });


### PR DESCRIPTION
# Description
template was trying to access ID and Name from xp value that didn't exist

Fixes #39

## Type of change
- [ x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [ ] I have updated the acceptance criteria on the task so that it can be tested