### PR TITLE
Add to cart popup + Quantity Input bugs

### DIFF
--- a/src/UI/Buyer/src/app/checkout/components/order-summary/order-summary.component.html
+++ b/src/UI/Buyer/src/app/checkout/components/order-summary/order-summary.component.html
@@ -9,4 +9,3 @@
     <div class="text-right lead"><b class="float-left">Total</b><span class="order-total">{{order.Total | currency}}</span></div>
   </div>
 </div>
-<button class="btn btn-primary btn-block mb-4 font-weight-bold" routerLink="/checkout">CHECKOUT</button>

--- a/src/UI/Buyer/src/app/checkout/containers/cart/cart.component.html
+++ b/src/UI/Buyer/src/app/checkout/containers/cart/cart.component.html
@@ -16,8 +16,11 @@
          *ngIf="order.LineItemCount">
       <div class="col-lg-4">
         <checkout-order-summary [order]="order"></checkout-order-summary>
+        <button class="btn btn-primary btn-block mb-4 font-weight-bold"
+                routerLink="/checkout">CHECKOUT</button>
       </div>
-      <div class="col-lg-8" *ngIf="productsSet">
+      <div class="col-lg-8"
+           *ngIf="productsSet">
         <shared-lineitem-list-wrapper>
           <shared-line-item-card *ngFor="let li of lineItems.Items"
                                  [lineitem]="li"

--- a/src/UI/Buyer/src/app/layout/header/header.component.html
+++ b/src/UI/Buyer/src/app/layout/header/header.component.html
@@ -98,7 +98,7 @@
         <a class="nav-link"
            routerLink="/cart"
            routerLinkActive="active"
-           ngbPopover="Item Added to Your Cart"
+           ngbPopover="Item(s) Added to Cart"
            placement="bottom"
            triggers="manual"
            #p="ngbPopover">

--- a/src/UI/Buyer/src/app/layout/header/header.component.spec.ts
+++ b/src/UI/Buyer/src/app/layout/header/header.component.spec.ts
@@ -1,10 +1,4 @@
-import {
-  async,
-  ComponentFixture,
-  TestBed,
-  fakeAsync,
-  tick,
-} from '@angular/core/testing';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
 import { HttpClientModule } from '@angular/common/http';
@@ -17,13 +11,11 @@ import {
 } from '@app-buyer/shared';
 import {
   OcTokenService,
-  Configuration,
   OcAuthService,
   OcMeService,
   OcLineItemService,
   OcSupplierService,
   OcOrderService,
-  Order,
 } from '@ordercloud/angular-sdk';
 
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
@@ -34,12 +26,12 @@ import {
   AppConfig,
 } from '@app-buyer/config/app.config';
 import { InjectionToken, NO_ERRORS_SCHEMA } from '@angular/core';
-import { BehaviorSubject } from 'rxjs';
 
 describe('HeaderComponent', () => {
   let component: HeaderComponent;
   let fixture: ComponentFixture<HeaderComponent>;
-  const orderSubject$ = new BehaviorSubject<Order>(null);
+
+  const mockOrder = { ID: 'orderID' };
 
   const ocTokenService = { RemoveAccess: jasmine.createSpy('RemoveAccess') };
   const baseResolveService = { resetUser: jasmine.createSpy('resetUser') };
@@ -82,6 +74,7 @@ describe('HeaderComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(HeaderComponent);
     component = fixture.componentInstance;
+    component.alive = true;
     fixture.detectChanges();
   });
 
@@ -91,26 +84,15 @@ describe('HeaderComponent', () => {
 
   describe('ngOnInit', () => {
     beforeEach(() => {
-      component.popover = fixture.componentInstance.popover;
-      component.currentOrder = { LineItemCount: 0 };
-      spyOn(component, 'addedToCart');
+      appStateService.orderSubject.next(mockOrder);
+      spyOn(component, 'buildAddToCartNotification');
       component.ngOnInit();
     });
-    it('should call added to cart if line item count has changed', () => {
-      appStateService.orderSubject.next({ LineItemCount: 1 });
-      appStateService.orderSubject.next({ LineItemCount: 2 });
-      appStateService.orderSubject.subscribe((order) => {
-        expect(order.LineItemCount).toBe(2);
-        expect(component.addedToCart).toHaveBeenCalled();
-      });
+    it('should define currentOrder', () => {
+      expect(component.currentOrder).toEqual(mockOrder);
     });
-    it('should not call added to cart if line item count is the same', () => {
-      appStateService.orderSubject.next({ LineItemCount: 1 });
-      appStateService.orderSubject.next({ LineItemCount: 1 });
-      appStateService.orderSubject.subscribe((order) => {
-        expect(order.LineItemCount).toBe(1);
-        expect(component.addedToCart).not.toHaveBeenCalled();
-      });
+    it('should call buildAddToCartNotification', () => {
+      expect(component.buildAddToCartNotification).toHaveBeenCalled();
     });
   });
 
@@ -132,23 +114,5 @@ describe('HeaderComponent', () => {
       component.logout();
       expect(router.navigate).toHaveBeenCalledWith(['/login']);
     });
-  });
-
-  describe('addedToCart', () => {
-    beforeEach(() => {
-      spyOn(component.popover, 'open');
-      spyOn(component.popover, 'close');
-    });
-    it(
-      'should open popover and close it after 5 seconds',
-      fakeAsync(() => {
-        component.addedToCart();
-        expect(component.popover.open).toHaveBeenCalled();
-        tick(4500);
-        expect(component.popover.close).not.toHaveBeenCalled();
-        tick(500);
-        expect(component.popover.close).toHaveBeenCalled();
-      })
-    );
   });
 });

--- a/src/UI/Buyer/src/app/layout/home/home.component.html
+++ b/src/UI/Buyer/src/app/layout/home/home.component.html
@@ -9,8 +9,8 @@
            [src]="slide.URL"
            alt="Random first slide">
       <div class="carousel-caption">
-        <h3>{{ slide.HeaderText }}</h3>
-        <p>{{ slide.BodyText }}</p>
+        <h3>{{ slide.headerText }}</h3>
+        <p>{{ slide.bodyText }}</p>
       </div>
     </ng-template>
   </ngb-carousel>

--- a/src/UI/Buyer/src/app/products/containers/product-details/product-details.component.ts
+++ b/src/UI/Buyer/src/app/products/containers/product-details/product-details.component.ts
@@ -8,7 +8,7 @@ import {
 import { ActivatedRoute } from '@angular/router';
 import { Observable, forkJoin, of } from 'rxjs';
 import { flatMap, tap } from 'rxjs/operators';
-import { AppLineItemService } from '@app-buyer/shared';
+import { AppLineItemService, AppStateService } from '@app-buyer/shared';
 import { BuyerProduct, OcMeService } from '@ordercloud/angular-sdk';
 import { QuantityInputComponent } from '@app-buyer/shared/components/quantity-input/quantity-input.component';
 import { AddToCartEvent } from '@app-buyer/shared/models/add-to-cart-event.interface';
@@ -33,6 +33,7 @@ export class ProductDetailsComponent implements OnInit, AfterViewChecked {
     private activatedRoute: ActivatedRoute,
     private appLineItemService: AppLineItemService,
     private favoriteProductsService: FavoriteProductsService,
+    private appStateService: AppStateService,
     private changeDetectorRef: ChangeDetectorRef
   ) {}
 
@@ -76,7 +77,9 @@ export class ProductDetailsComponent implements OnInit, AfterViewChecked {
   }
 
   addToCart(event: AddToCartEvent): void {
-    this.appLineItemService.create(event.product, event.quantity).subscribe();
+    this.appLineItemService
+      .create(event.product, event.quantity)
+      .subscribe(() => this.appStateService.addToCartSubject.next(event));
   }
 
   isOrderable(): boolean {

--- a/src/UI/Buyer/src/app/products/containers/product-list/product-list.component.spec.ts
+++ b/src/UI/Buyer/src/app/products/containers/product-list/product-list.component.spec.ts
@@ -1,7 +1,11 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ProductListComponent } from '@app-buyer/products/containers/product-list/product-list.component';
-import { PageTitleComponent, AppLineItemService } from '@app-buyer/shared';
+import {
+  PageTitleComponent,
+  AppLineItemService,
+  AppStateService,
+} from '@app-buyer/shared';
 import {
   NgbPaginationModule,
   NgbCollapseModule,
@@ -49,6 +53,7 @@ describe('ProductListComponent', () => {
   const favoriteProductsService = {
     loadFavorites: jasmine.createSpy('loadFavorites'),
   };
+  let appStateService: AppStateService;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -70,6 +75,7 @@ describe('ProductListComponent', () => {
         FontAwesomeModule,
       ],
       providers: [
+        AppStateService,
         NgbPaginationConfig,
         { provide: AppLineItemService, useValue: ocLineItemService },
         {
@@ -80,6 +86,7 @@ describe('ProductListComponent', () => {
         { provide: FavoriteProductsService, useValue: favoriteProductsService },
       ],
     }).compileComponents();
+    appStateService = TestBed.get(AppStateService);
   }));
 
   beforeEach(() => {
@@ -231,12 +238,18 @@ describe('ProductListComponent', () => {
     describe('addToCart', () => {
       const mockEvent = { product: { ID: 'MockProduct' }, quantity: 3 };
       beforeEach(() => {
+        spyOn(appStateService.addToCartSubject, 'next');
         component.addToCart(mockEvent);
       });
       it('should call ocLineItemService.Create', () => {
         expect(ocLineItemService.create).toHaveBeenCalledWith(
           mockEvent.product,
           mockEvent.quantity
+        );
+      });
+      it('should call AppStateService.addToCartEvent', () => {
+        expect(appStateService.addToCartSubject.next).toHaveBeenCalledWith(
+          mockEvent
         );
       });
     });

--- a/src/UI/Buyer/src/app/products/containers/product-list/product-list.component.ts
+++ b/src/UI/Buyer/src/app/products/containers/product-list/product-list.component.ts
@@ -10,7 +10,7 @@ import {
   ListCategory,
 } from '@ordercloud/angular-sdk';
 import { ProductSortStrats } from '@app-buyer/products/models/product-sort-strats.enum';
-import { AppLineItemService } from '@app-buyer/shared';
+import { AppLineItemService, AppStateService } from '@app-buyer/shared';
 import { AddToCartEvent } from '@app-buyer/shared/models/add-to-cart-event.interface';
 import { faTimes } from '@fortawesome/free-solid-svg-icons';
 import { ToggleFavoriteComponent } from '@app-buyer/shared/components/toggle-favorite/toggle-favorite.component';
@@ -39,7 +39,8 @@ export class ProductListComponent implements OnInit {
     private router: Router,
     private formBuilder: FormBuilder,
     private appLineItemService: AppLineItemService,
-    private favoriteProductsService: FavoriteProductsService
+    private favoriteProductsService: FavoriteProductsService,
+    private appStateService: AppStateService
   ) {}
 
   ngOnInit() {
@@ -138,7 +139,9 @@ export class ProductListComponent implements OnInit {
   }
 
   addToCart(event: AddToCartEvent) {
-    this.appLineItemService.create(event.product, event.quantity).subscribe();
+    this.appLineItemService
+      .create(event.product, event.quantity)
+      .subscribe(() => this.appStateService.addToCartSubject.next(event));
   }
 
   refineByFavorites() {

--- a/src/UI/Buyer/src/app/shared/services/app-state/app-state.service.ts
+++ b/src/UI/Buyer/src/app/shared/services/app-state/app-state.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, Subject } from 'rxjs';
 import { MeUser, Order, ListLineItem } from '@ordercloud/angular-sdk';
+import { AddToCartEvent } from '@app-buyer/shared/models/add-to-cart-event.interface';
 
 @Injectable()
 export class AppStateService {
@@ -10,6 +11,8 @@ export class AppStateService {
   public isAnonSubject: BehaviorSubject<boolean>;
   public lineItemSubject: BehaviorSubject<ListLineItem>;
 
+  public addToCartSubject: Subject<AddToCartEvent>;
+
   constructor() {
     this.userSubject = new BehaviorSubject<MeUser>(null);
     this.orderSubject = new BehaviorSubject<Order>(null);
@@ -18,5 +21,7 @@ export class AppStateService {
       Meta: { Page: 1, PageSize: 25, TotalCount: 0, TotalPages: 1 },
       Items: [],
     });
+
+    this.addToCartSubject = new Subject<AddToCartEvent>();
   }
 }

--- a/src/UI/Buyer/src/app/shared/validators/oc-product-quantity/oc-product-quantity.validator.spec.ts
+++ b/src/UI/Buyer/src/app/shared/validators/oc-product-quantity/oc-product-quantity.validator.spec.ts
@@ -66,4 +66,14 @@ describe('OcMaxProductQty Validator', () => {
       expect(OcMaxProductQty(mockProduct)(new FormControl(1))).toBe(null);
     });
   });
+  describe('QuantityAvailable of zero should produce error', () => {
+    const mockProduct = {
+      Inventory: { QuantityAvailable: 0 },
+    };
+    it('should return a validation error on value larger than zero', () => {
+      expect(OcMaxProductQty(mockProduct)(new FormControl(1))).toEqual({
+        OcMaxProductQty: { max: 0, actual: 1 },
+      });
+    });
+  });
 });

--- a/src/UI/Buyer/src/app/shared/validators/oc-product-quantity/oc-product.quantity.validator.ts
+++ b/src/UI/Buyer/src/app/shared/validators/oc-product-quantity/oc-product.quantity.validator.ts
@@ -49,10 +49,10 @@ function getMaxQty(product: BuyerProduct): number {
   let quantityAvailable = Infinity;
   let permissionLimit = Infinity;
 
-  if (product.Inventory && product.Inventory.QuantityAvailable) {
+  if (product.Inventory && product.Inventory.QuantityAvailable != null) {
     quantityAvailable = product.Inventory.QuantityAvailable;
   }
-  if (product.PriceSchedule && product.PriceSchedule.MaxQuantity) {
+  if (product.PriceSchedule && product.PriceSchedule.MaxQuantity != null) {
     permissionLimit = product.PriceSchedule.MaxQuantity;
   }
   return Math.min(quantityAvailable, permissionLimit);


### PR DESCRIPTION
# Description

- Add to cart notification now shows up when you re-add a repeat product. If you add another while it is open, it goes away and comes back to indicate the change. Product quantities are reset on add.
- Bug where restricted quantity products are always the lowest option is gone.
- Misc - removed duplicate checkout button, brought text back to the home page carousel, handled case where inventory =0;

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [ ] I have updated the acceptance criteria on the task so that it can be tested