### PR TITLE
Add Category Selection Indicator

### DIFF
--- a/src/UI/Buyer/src/app/products/components/category-nav/category-nav.component.spec.ts
+++ b/src/UI/Buyer/src/app/products/components/category-nav/category-nav.component.spec.ts
@@ -3,10 +3,13 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { CategoryNavComponent } from '@app-buyer/products/components/category-nav/category-nav.component';
 import { TreeModule } from 'angular-tree-component';
 import { CategoryTreeNode } from '@app-buyer/products/models/category-tree-node.class';
+import { BehaviorSubject } from 'rxjs';
+import { ActivatedRoute } from '@angular/router';
 
 describe('CategoryNavComponent', () => {
   let component: CategoryNavComponent;
   let fixture: ComponentFixture<CategoryNavComponent>;
+  let mockCategoryID = '12345';
   const TreeNode = (fields) => {
     const node = new CategoryTreeNode();
     if (fields.id) {
@@ -25,9 +28,16 @@ describe('CategoryNavComponent', () => {
     return node;
   };
 
+  const queryParams = new BehaviorSubject<any>({ category: mockCategoryID });
+  const activatedRoute = {
+    navigate: jasmine.createSpy('navigate'),
+    queryParams,
+  };
+
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [CategoryNavComponent],
+      providers: [{ provide: ActivatedRoute, useValue: activatedRoute }],
       imports: [TreeModule],
     }).compileComponents();
   }));

--- a/src/UI/Buyer/src/app/products/components/category-nav/category-nav.component.ts
+++ b/src/UI/Buyer/src/app/products/components/category-nav/category-nav.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 import { ListCategory, Category } from '@ordercloud/angular-sdk';
 import { ITreeOptions } from 'angular-tree-component';
 import { CategoryTreeNode } from '@app-buyer/products/models/category-tree-node.class';
+import { ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'products-category-nav',
@@ -12,7 +13,11 @@ export class CategoryNavComponent implements OnInit {
   @Input() categories: ListCategory;
   @Output() selection = new EventEmitter<CategoryTreeNode>();
   categoryTree: CategoryTreeNode[];
+  private activeCategoryID: string;
   options: ITreeOptions = {
+    nodeClass: (node: CategoryTreeNode) => {
+      return this.activeCategoryID == node.id ? 'font-weight-bold' : null;
+    },
     actionMapping: {
       mouse: {
         click: (_tree, _node, _$event) => {
@@ -23,10 +28,15 @@ export class CategoryNavComponent implements OnInit {
     animateExpand: true,
   };
 
-  constructor() {}
+  constructor(
+    private activatedRoute: ActivatedRoute
+  ) { }
 
   ngOnInit() {
     this.categoryTree = this.buildCategoryTree(this.categories.Items);
+    this.activatedRoute.queryParams.subscribe((queryParams) => {
+      this.activeCategoryID = queryParams.category;
+    })
   }
 
   buildCategoryTree(ocCategories: Category[]): CategoryTreeNode[] {


### PR DESCRIPTION
# Description

- Subscribe a new property `activeCategoryID` to `activatedRoute.queryParams.category`. Use this property in the `ITreeOptions.nodeClass` callback to add a `.font-weight-bold` class to the currently selected category.
- Learning to walk again
- Had to add activatedRoute to the unit tests

For Reference #89 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the acceptance criteria on the task so that it can be tested
