### PR TITLE
refactor: put favorites in the query params and introduce clear all filters button

### DIFF
--- a/src/UI/Buyer/src/app/order/components/order-list/order-list.component.html
+++ b/src/UI/Buyer/src/app/order/components/order-list/order-list.component.html
@@ -8,39 +8,39 @@
         <th (click)="updateSort('ID')"
             *ngIf="columns.indexOf('ID') > -1">
           <button class="btn btn-link font-weight-bold">
-              ID
-              <fa-icon *ngIf="sortBy === 'ID' || sortBy === '!ID'"
-                       [icon]="sortBy === 'ID' ? faCaretDown : faCaretUp"></fa-icon>
+            ID
+            <fa-icon *ngIf="sortBy === 'ID' || sortBy === '!ID'"
+                     [icon]="sortBy === 'ID' ? faCaretDown : faCaretUp"></fa-icon>
           </button>
         </th>
         <th (click)="updateSort('Status')"
             *ngIf="columns.indexOf('Status') > -1">
           <button class="btn btn-link font-weight-bold">
-                Status
-                <fa-icon *ngIf="sortBy === 'Status' || sortBy === '!Status'"
-                         [icon]="sortBy === 'Status' ? faCaretDown : faCaretUp"></fa-icon>
-            </button>
+            Status
+            <fa-icon *ngIf="sortBy === 'Status' || sortBy === '!Status'"
+                     [icon]="sortBy === 'Status' ? faCaretDown : faCaretUp"></fa-icon>
+          </button>
         </th>
         <th (click)="updateSort('DateSubmitted')"
             *ngIf="columns.indexOf('DateSubmitted') > -1">
           <button class="btn btn-link font-weight-bold">
-                Date Submitted
-                <fa-icon *ngIf="sortBy === 'DateSubmitted' || sortBy === '!DateSubmitted'"
-                         [icon]="sortBy === 'DateSubmitted' ? faCaretDown : faCaretUp"></fa-icon>
-            </button>
+            Date Submitted
+            <fa-icon *ngIf="sortBy === 'DateSubmitted' || sortBy === '!DateSubmitted'"
+                     [icon]="sortBy === 'DateSubmitted' ? faCaretDown : faCaretUp"></fa-icon>
+          </button>
         </th>
         <th *ngIf="columns.indexOf('SubmittedBy') > -1">
           <button class="btn btn-link font-weight-bold">
-                Submitted By
-            </button>
+            Submitted By
+          </button>
         </th>
         <th (click)="updateSort('Total')"
             *ngIf="columns.indexOf('Total') > -1">
           <button class="btn btn-link font-weight-bold">
-                Total
-                <fa-icon *ngIf="sortBy === 'Total' || sortBy === '!Total'"
-                         [icon]="sortBy === 'Total' ? faCaretDown : faCaretUp"></fa-icon>
-            </button>
+            Total
+            <fa-icon *ngIf="sortBy === 'Total' || sortBy === '!Total'"
+                     [icon]="sortBy === 'Total' ? faCaretDown : faCaretUp"></fa-icon>
+          </button>
         </th>
       </tr>
     </thead>

--- a/src/UI/Buyer/src/app/order/containers/order-history/order-history.component.html
+++ b/src/UI/Buyer/src/app/order/containers/order-history/order-history.component.html
@@ -5,7 +5,7 @@
   <div class="col-2">
     <div>Favorites</div>
     <div class="mt-3 ml-3">
-      <shared-toggle-favorite [favorite]="showfavoritesOnly"
+      <shared-toggle-favorite [favorite]="hasFavoriteOrdersFilter"
                               (favoriteChanged)="filterByFavorite($event)"></shared-toggle-favorite>
     </div>
   </div>

--- a/src/UI/Buyer/src/app/order/containers/order-history/order-history.component.spec.ts
+++ b/src/UI/Buyer/src/app/order/containers/order-history/order-history.component.spec.ts
@@ -17,6 +17,7 @@ import { of, Subject } from 'rxjs';
 import { take } from 'rxjs/operators';
 import { OrderStatusDisplayPipe } from '@app-buyer/shared/pipes/order-status-display/order-status-display.pipe';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { AppStateService } from '@app-buyer/shared';
 
 describe('OrderHistoryComponent', () => {
   let component: OrderHistoryComponent;
@@ -57,6 +58,7 @@ describe('OrderHistoryComponent', () => {
       imports: [ReactiveFormsModule, NgbPaginationModule, NgbRootModule],
       providers: [
         DatePipe,
+        { provide: AppStateService, useValue: {} },
         { provide: OcMeService, useValue: meService },
         { provide: Router, useValue: router },
         { provide: ActivatedRoute, useValue: activatedRoute },
@@ -75,10 +77,10 @@ describe('OrderHistoryComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  describe('ngOnInit', () => {
+  describe('ngAfterViewInit', () => {
     beforeEach(() => {
       spyOn(component as any, 'listOrders');
-      component.ngOnInit();
+      component.ngAfterViewInit();
     });
     it('should call list orders', () => {
       expect(component['listOrders']).toHaveBeenCalled();
@@ -145,8 +147,7 @@ describe('OrderHistoryComponent', () => {
       page: 1,
       filters: {
         status: 'Open',
-        datesubmitted: ['5-30-18'],
-        ID: undefined,
+        datesubmitted: ['5-30-18']
       },
     };
     beforeEach(() => {
@@ -167,14 +168,15 @@ describe('OrderHistoryComponent', () => {
   describe('filterByFavorite', () => {
     beforeEach(() => {
       meService.ListOrders.calls.reset();
+      spyOn(component as any, 'addQueryParam');
     });
     it('should show favorites only when true', () => {
       component['filterByFavorite'](true);
-      expect(component.showfavoritesOnly).toEqual(true);
+      expect(component['addQueryParam']).toHaveBeenCalledWith({ favoriteOrders: true })
     });
     it('should show all products when false', () => {
       component['filterByFavorite'](false);
-      expect(component.showfavoritesOnly).toEqual(false);
+      expect(component['addQueryParam']).toHaveBeenCalledWith({ favoriteOrders: undefined })
     });
   });
 });

--- a/src/UI/Buyer/src/app/products/containers/product-details/product-details.component.html
+++ b/src/UI/Buyer/src/app/products/containers/product-details/product-details.component.html
@@ -10,11 +10,10 @@
       <h1 class="h1 my-0">{{ product.Name }}</h1>
       <span class="text-muted">ID: {{ product.ID }}</span>
       <span class="ml-3">
-        <shared-toggle-favorite 
-          title="Favorite"
-          (click)="$event.stopPropagation()"
-          [favorite]="favoriteProductsService.isFavorite(product)"
-          (favoriteChanged)="favoriteProductsService.setFavoriteValue($event, product)">
+        <shared-toggle-favorite title="Favorite"
+                                (click)="$event.stopPropagation()"
+                                [favorite]="favoriteProductsService.isFavorite(product)"
+                                (favoriteChanged)="favoriteProductsService.setFavoriteValue($event, product)">
         </shared-toggle-favorite>
       </span>
       <hr>
@@ -26,7 +25,8 @@
         </shared-quantity-input>
         <button class="btn btn-primary ml-2"
                 type="submit"
-                (click)="quantityInputComponent.addToCart($event)">Add to Cart <span class="badge badge-light ml-2">{{ getTotalPrice() | currency }}</span></button>
+                (click)="quantityInputComponent.addToCart($event)">Add to Cart
+          <span class="badge badge-light ml-2">{{ getTotalPrice() | currency }}</span></button>
       </div>
       <ng-template #viewOnly>
         <div class="alert alert-info">

--- a/src/UI/Buyer/src/app/products/containers/product-list/product-list.component.html
+++ b/src/UI/Buyer/src/app/products/containers/product-list/product-list.component.html
@@ -9,15 +9,17 @@
         <a *ngFor="let cat of categoryCrumbs"
            class="breadcrumb-item link-text"
            [queryParams]="{ category: cat.ID }"
-           [routerLink]="['/products']">{{ cat.Name }}</a>
+           [routerLink]="['/products']">{{
+          cat.Name }}</a>
       </nav>
     </div>
   </div>
   <div class="row">
     <div class="col-md-4 col-lg-3 d-md-block d-sm-none d-none">
-      <products-category-nav *ngIf="categories"
-                             [categories]="categories"
-                             (selection)="changeCategory($event)"></products-category-nav>
+      <button *ngIf="hasQueryParams"
+              class="btn btn-default mb-4"
+              type="button"
+              (click)="clearAllFilters()">Clear All Filters</button>
       <div class="card mb-4">
         <div class="card-header p-3">
           <h5 class="card-title mb-0">
@@ -25,21 +27,24 @@
           </h5>
         </div>
         <div class="p-3">
-          <shared-toggle-favorite id="favorite"
-                                  [favorite]="favsFilterOn"
-                                  (favoriteChanged)="setFavsFilter($event)"></shared-toggle-favorite>
-          <label class="ml-2 cursor-pointer"
-                 (click)="refineByFavorites()"
-                 for="favorite"> My Favorites</label>
+          <div (click)="refineByFavorites()">
+            <shared-toggle-favorite id="favorite"
+                                    [favorite]="hasFavoriteProductsFilter"></shared-toggle-favorite>
+            <label class="ml-2"
+                   for="favorite"> My Favorites</label>
+          </div>
         </div>
       </div>
+      <products-category-nav *ngIf="categories?.Items?.length"
+                             [categories]="categories"
+                             (selection)="changeCategory($event)"></products-category-nav>
     </div>
     <div class="col-lg-9 col-md-8">
       <div class="row justify-content-between">
         <div class="col-auto">
           <div class="m-0 mt-1">
             <span *ngIf="productList.Meta.TotalPages > 1">
-             {{ ((productList.Meta.Page - 1) * productList.Meta.PageSize) + 1 }} - {{productList.Meta.Page * productList.Meta.PageSize}} of 
+              {{ ((productList.Meta.Page - 1) * productList.Meta.PageSize) + 1 }} - {{productList.Meta.Page * productList.Meta.PageSize}} of
             </span>{{productList.Meta.TotalCount}} results
           </div>
         </div>
@@ -49,11 +54,13 @@
               <select class="form-control"
                       formControlName="sortBy"
                       (change)="sortStratChanged()">
-              <option [ngValue]="null" disabled>None</option>
-              <option [ngValue]="sortOption.key" *ngFor="let sortOption of sortOptions | mapToIterable">
-                {{ sortOption.value }}
-              </option>
-            </select>
+                <option [ngValue]="null"
+                        disabled>None</option>
+                <option [ngValue]="sortOption.key"
+                        *ngFor="let sortOption of sortOptions | mapToIterable">
+                  {{ sortOption.value }}
+                </option>
+              </select>
             </div>
             <div class="float-right mt-1 mr-2">Sort By</div>
           </form>

--- a/src/UI/Buyer/src/app/products/containers/product-list/product-list.component.ts
+++ b/src/UI/Buyer/src/app/products/containers/product-list/product-list.component.ts
@@ -57,7 +57,6 @@ export class ProductListComponent implements OnInit {
   getProductData(): Observable<ListBuyerProduct> {
     return this.activatedRoute.queryParams.pipe(
       tap((queryParams) => {
-        debugger;
         this.hasFavoriteProductsFilter =
           queryParams.favoriteProducts === 'true';
         this.hasQueryParams = !_isEmpty(queryParams);

--- a/src/UI/Buyer/src/app/shared/components/product-card/product-card.component.html
+++ b/src/UI/Buyer/src/app/shared/components/product-card/product-card.component.html
@@ -38,11 +38,12 @@
             class="btn btn-primary btn-block small"
             type="submit"
             (click)="quantityInputComponent.addToCart($event)">
-            Add <span class="d-md-none d-lg-inline">to Cart</span>
-        </button>
+      Add <span class="d-md-none d-lg-inline">to Cart</span>
+    </button>
     <button *ngIf="isViewOnlyProduct"
             [routerLink]="['/products', product.ID]"
-            class="btn btn-default btn-block btn-outline-dark">View <span class="d-sm-none d-lg-inline">Product</span>
-      </button>
+            class="btn btn-default btn-block btn-outline-dark">View
+      <span class="d-sm-none d-lg-inline">Product</span>
+    </button>
   </div>
 </div>

--- a/src/UI/Buyer/src/app/shared/services/favorites/favorites.service.spec.ts
+++ b/src/UI/Buyer/src/app/shared/services/favorites/favorites.service.spec.ts
@@ -1,70 +1,67 @@
 import { TestBed, inject, async } from '@angular/core/testing';
 
-import { OcMeService } from '@ordercloud/angular-sdk';
-import { of } from 'rxjs';
+import { OcMeService, MeUser } from '@ordercloud/angular-sdk';
+import { of, BehaviorSubject } from 'rxjs';
 import { FavoriteProductsService } from '@app-buyer/shared/services/favorites/favorites.service';
+import { AppStateService } from '@app-buyer/shared/services/app-state/app-state.service';
 
 describe('FavoriteProductsService', () => {
+
+  let service;
   const meService = {
     Get: jasmine.createSpy('Get').and.returnValue(of({})),
     Patch: jasmine
       .createSpy('Patch')
       .and.returnValue(of({ xp: { FavoriteProducts: [] } })),
   };
+  const appStateService = {
+    userSubject: new BehaviorSubject<MeUser>({ xp: { 'FavoriteProducts': ['Id1', 'Id2'] } })
+  }
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       providers: [
         FavoriteProductsService,
+        { provide: AppStateService, useValue: appStateService },
         { provide: OcMeService, useValue: meService },
       ],
     });
+    service = TestBed.get(FavoriteProductsService);
   }));
 
-  it('should be created', inject(
-    [FavoriteProductsService],
-    (service: FavoriteProductsService) => {
-      expect(service).toBeTruthy();
-    }
-  ));
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  })
 
-  it('isProductFav should return true for a favorite', inject(
-    [FavoriteProductsService],
-    (service: FavoriteProductsService) => {
-      service.favorites = ['a', 'b', 'c'];
-      expect(service.isFavorite({ ID: 'a' })).toEqual(true);
-    }
-  ));
+  it('isProductFav should return true for a favorite', () => {
+    service.favorites = ['a', 'b', 'c'];
+    expect(service.isFavorite({ ID: 'a' })).toEqual(true);
+  }
+  );
 
-  it('isProductFav should return false for a non-favorite', inject(
-    [FavoriteProductsService],
-    (service: FavoriteProductsService) => {
-      service.favorites = ['a', 'b', 'c'];
-      expect(service.isFavorite({ ID: 'd' })).toEqual(false);
-    }
-  ));
+  it('isProductFav should return false for a non-favorite', () => {
+    service.favorites = ['a', 'b', 'c'];
+    expect(service.isFavorite({ ID: 'd' })).toEqual(false);
+  }
+  );
 
-  it('setProductAsFav should remove fav correctly', inject(
-    [FavoriteProductsService],
-    (service: FavoriteProductsService) => {
-      meService.Patch.calls.reset();
-      service.favorites = ['a', 'b'];
-      service.setFavoriteValue(false, { ID: 'a' });
-      expect(meService.Patch).toHaveBeenCalledWith({
-        xp: { FavoriteProducts: ['b'] },
-      });
-    }
-  ));
+  it('setProductAsFav should remove fav correctly', () => {
+    meService.Patch.calls.reset();
+    service.favorites = ['a', 'b'];
+    service.setFavoriteValue(false, { ID: 'a' });
+    expect(meService.Patch).toHaveBeenCalledWith({
+      xp: { FavoriteProducts: ['b'] },
+    });
+  }
+  );
 
-  it('setProductAsFav should add fav correctly', inject(
-    [FavoriteProductsService],
-    (service: FavoriteProductsService) => {
-      meService.Patch.calls.reset();
-      service.favorites = ['a', 'b'];
-      service.setFavoriteValue(true, { ID: 'c' });
-      expect(meService.Patch).toHaveBeenCalledWith({
-        xp: { FavoriteProducts: ['a', 'b', 'c'] },
-      });
-    }
-  ));
+  it('setProductAsFav should add fav correctly', () => {
+    meService.Patch.calls.reset();
+    service.favorites = ['a', 'b'];
+    service.setFavoriteValue(true, { ID: 'c' });
+    expect(meService.Patch).toHaveBeenCalledWith({
+      xp: { FavoriteProducts: ['a', 'b', 'c'] },
+    });
+  }
+  );
 });

--- a/src/UI/Buyer/src/app/shared/services/favorites/favorites.service.ts
+++ b/src/UI/Buyer/src/app/shared/services/favorites/favorites.service.ts
@@ -16,7 +16,7 @@ abstract class FavoritesService<T extends { ID?: string }> {
   constructor(
     private appStateService: AppStateService,
     private ocMeService: OcMeService
-  ) {}
+  ) { }
 
   loadFavorites(): void {
     if (this.favorites !== null) {
@@ -42,6 +42,7 @@ abstract class FavoritesService<T extends { ID?: string }> {
     const request = { xp: {} };
     request.xp[this.XpFieldName] = this.favorites;
     this.ocMeService.Patch(request).subscribe((me) => {
+      this.appStateService.userSubject.next(me);
       this.favorites = me.xp[this.XpFieldName];
     });
   }

--- a/src/UI/Buyer/src/app/shared/services/favorites/favorites.service.ts
+++ b/src/UI/Buyer/src/app/shared/services/favorites/favorites.service.ts
@@ -1,5 +1,11 @@
 import { Injectable, Inject } from '@angular/core';
-import { OcMeService, BuyerProduct, Order } from '@ordercloud/angular-sdk';
+import {
+  OcMeService,
+  BuyerProduct,
+  Order,
+  MeUser,
+} from '@ordercloud/angular-sdk';
+import { AppStateService } from '@app-buyer/shared';
 
 abstract class FavoritesService<T extends { ID?: string }> {
   protected readonly XpFieldName: string;
@@ -7,14 +13,17 @@ abstract class FavoritesService<T extends { ID?: string }> {
   // Array of object IDs
   public favorites: string[] = null;
 
-  constructor(private ocMeService: OcMeService) {}
+  constructor(
+    private appStateService: AppStateService,
+    private ocMeService: OcMeService
+  ) {}
 
   loadFavorites(): void {
     if (this.favorites !== null) {
       return;
     }
 
-    this.ocMeService.Get().subscribe((me) => {
+    this.appStateService.userSubject.subscribe((me: MeUser) => {
       this.favorites =
         me.xp && me.xp[this.XpFieldName] ? me.xp[this.XpFieldName] : [];
     });
@@ -25,11 +34,6 @@ abstract class FavoritesService<T extends { ID?: string }> {
   }
 
   setFavoriteValue(isFav: boolean, object: T): void {
-    // TODO - is there a better solution if the favorites havn't loaded yet?
-    if (this.favorites === null) {
-      return;
-    }
-
     if (isFav) {
       this.favorites.push(object.ID);
     } else {
@@ -49,8 +53,11 @@ abstract class FavoritesService<T extends { ID?: string }> {
 export class FavoriteProductsService extends FavoritesService<BuyerProduct> {
   protected readonly XpFieldName = 'FavoriteProducts';
 
-  constructor(@Inject(OcMeService) ocMeService: OcMeService) {
-    super(ocMeService);
+  constructor(
+    @Inject(AppStateService) appStateService: AppStateService,
+    @Inject(OcMeService) ocMeService: OcMeService
+  ) {
+    super(appStateService, ocMeService);
   }
 }
 
@@ -60,7 +67,10 @@ export class FavoriteProductsService extends FavoritesService<BuyerProduct> {
 export class FavoriteOrdersService extends FavoritesService<Order> {
   protected readonly XpFieldName = 'FavoriteOrders';
 
-  constructor(@Inject(OcMeService) ocMeService: OcMeService) {
-    super(ocMeService);
+  constructor(
+    @Inject(AppStateService) appStateService: AppStateService,
+    @Inject(OcMeService) ocMeService: OcMeService
+  ) {
+    super(appStateService, ocMeService);
   }
 }


### PR DESCRIPTION
# Description

This is somewhat in preparation for faceted navigation but in general I just think its a nice thing to have any filterable thing be in the query params. This enables a couple of things:

1. The filter is there even after refresh
2. Allows us to use a single button to clear all filters

## Type of change
- [ x] New feature (non-breaking change which adds functionality)

# Checklist:

- [ x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [ ] I have updated the acceptance criteria on the task so that it can be tested
