### PR TITLE
refactor: make sort-filter component, remove load from favoriteProducts

### DIFF
--- a/src/UI/Buyer/src/app/order/components/order-list/order-list.component.spec.ts
+++ b/src/UI/Buyer/src/app/order/components/order-list/order-list.component.spec.ts
@@ -12,16 +12,10 @@ import {
   NgbDateCustomParserFormatter,
 } from '@app-buyer/config/date-picker.config';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { of } from 'rxjs';
-import { FavoriteOrdersService } from '@app-buyer/shared/services/favorites/favorites.service';
 
 describe('OrderListComponent', () => {
   let component: OrderListComponent;
   let fixture: ComponentFixture<OrderListComponent>;
-
-  const favoriteOrdersService = {
-    loadFavorites: jasmine.createSpy('loadFavorites').and.returnValue(of(null)),
-  };
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -33,7 +27,6 @@ describe('OrderListComponent', () => {
           provide: NgbDateParserFormatter,
           useClass: NgbDateCustomParserFormatter,
         },
-        { provide: FavoriteOrdersService, useValue: favoriteOrdersService },
       ],
       schemas: [NO_ERRORS_SCHEMA], // Ignore template errors: remove if tests are added to test template
     }).compileComponents();
@@ -51,13 +44,6 @@ describe('OrderListComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
-  });
-
-  describe('ngOnInit', () => {
-    it('should call loadFavorites', () => {
-      component.ngOnInit();
-      expect(favoriteOrdersService.loadFavorites).toHaveBeenCalled();
-    });
   });
 
   describe('updateSort', () => {

--- a/src/UI/Buyer/src/app/order/components/order-list/order-list.component.ts
+++ b/src/UI/Buyer/src/app/order/components/order-list/order-list.component.ts
@@ -1,15 +1,14 @@
-import { Component, Input, EventEmitter, Output, OnInit } from '@angular/core';
+import { Component, Input, EventEmitter, Output } from '@angular/core';
 import { ListOrder } from '@ordercloud/angular-sdk';
 import { OrderListColumn } from '@app-buyer/order/models/order-list-column';
 import { faCaretDown, faCaretUp } from '@fortawesome/free-solid-svg-icons';
-import { FavoriteOrdersService } from '@app-buyer/shared/services/favorites/favorites.service';
 
 @Component({
   selector: 'order-list',
   templateUrl: './order-list.component.html',
   styleUrls: ['./order-list.component.scss'],
 })
-export class OrderListComponent implements OnInit {
+export class OrderListComponent {
   @Input() orders: ListOrder;
   @Input() columns: OrderListColumn[];
   @Input() sortBy: string;
@@ -18,11 +17,7 @@ export class OrderListComponent implements OnInit {
   @Output() updatedSort = new EventEmitter<string>();
   @Output() changedPage = new EventEmitter<number>();
 
-  constructor(private favoriteOrdersService: FavoriteOrdersService) {}
-
-  ngOnInit() {
-    this.favoriteOrdersService.loadFavorites();
-  }
+  constructor() {}
 
   protected updateSort(selectedSortBy) {
     let sortBy;

--- a/src/UI/Buyer/src/app/order/containers/order-history/order-history.component.spec.ts
+++ b/src/UI/Buyer/src/app/order/containers/order-history/order-history.component.spec.ts
@@ -18,6 +18,7 @@ import { take } from 'rxjs/operators';
 import { OrderStatusDisplayPipe } from '@app-buyer/shared/pipes/order-status-display/order-status-display.pipe';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { AppStateService } from '@app-buyer/shared';
+import { FavoriteOrdersService } from '@app-buyer/shared/services/favorites/favorites.service';
 
 describe('OrderHistoryComponent', () => {
   let component: OrderHistoryComponent;
@@ -44,6 +45,10 @@ describe('OrderHistoryComponent', () => {
     queryParamMap,
   };
 
+  let favoriteOrdersService = {
+    getFavorites: () => {},
+  };
+
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [
@@ -62,9 +67,11 @@ describe('OrderHistoryComponent', () => {
         { provide: OcMeService, useValue: meService },
         { provide: Router, useValue: router },
         { provide: ActivatedRoute, useValue: activatedRoute },
+        { provide: FavoriteOrdersService, useValue: favoriteOrdersService },
       ],
       schemas: [NO_ERRORS_SCHEMA], // Ignore template errors: remove if tests are added to test template
     }).compileComponents();
+    favoriteOrdersService = TestBed.get(FavoriteOrdersService);
   }));
 
   beforeEach(() => {
@@ -140,6 +147,25 @@ describe('OrderHistoryComponent', () => {
     });
   });
 
+  describe('filterByFavorite', () => {
+    beforeEach(() => {
+      meService.ListOrders.calls.reset();
+      spyOn(component as any, 'addQueryParam');
+    });
+    it('should show favorites only when true', () => {
+      component['filterByFavorite'](true);
+      expect(component['addQueryParam']).toHaveBeenCalledWith({
+        favoriteOrders: true,
+      });
+    });
+    it('should show all products when false', () => {
+      component['filterByFavorite'](false);
+      expect(component['addQueryParam']).toHaveBeenCalledWith({
+        favoriteOrders: undefined,
+      });
+    });
+  });
+
   describe('listOrders', () => {
     const expected = {
       sortBy: '!ID',
@@ -147,13 +173,17 @@ describe('OrderHistoryComponent', () => {
       page: 1,
       filters: {
         status: 'Open',
-        datesubmitted: ['5-30-18']
+        datesubmitted: ['5-30-18'],
+        ID: '1|2|3',
       },
     };
     beforeEach(() => {
       meService.ListOrders.calls.reset();
     });
     it('should call meService.ListOrders with correct parameters', () => {
+      spyOn(component as any, 'buildFavoriteOrdersQuery').and.returnValue(
+        '1|2|3'
+      );
       component['listOrders']()
         .pipe(take(1))
         .subscribe(() => {
@@ -165,18 +195,64 @@ describe('OrderHistoryComponent', () => {
     });
   });
 
-  describe('filterByFavorite', () => {
-    beforeEach(() => {
-      meService.ListOrders.calls.reset();
-      spyOn(component as any, 'addQueryParam');
+  describe('buildFavoriteOrdersQuery', () => {
+    describe('hasFavoriteOrdersFilter', () => {
+      it('should be true if favoriteOrders param is string "true"', () => {
+        component['buildFavoriteOrdersQuery'](
+          convertToParamMap({ favoriteOrders: 'true' })
+        );
+        expect(component.hasFavoriteOrdersFilter).toBe(true);
+      });
+      it('should be false if favoriteOrders param is undefined', () => {
+        component['buildFavoriteOrdersQuery'](
+          convertToParamMap({ favoriteOrders: undefined })
+        );
+        expect(component.hasFavoriteOrdersFilter).toBe(false);
+      });
+      it('should be false if favoriteOrders param is null', () => {
+        component['buildFavoriteOrdersQuery'](
+          convertToParamMap({ favoriteOrders: null })
+        );
+        expect(component.hasFavoriteOrdersFilter).toBe(false);
+      });
+      it('should be false if favoriteOrders param does not exist', () => {
+        component['buildFavoriteOrdersQuery'](
+          convertToParamMap({ anotherParam: 'blah' })
+        );
+        expect(component.hasFavoriteOrdersFilter).toBe(false);
+      });
     });
-    it('should show favorites only when true', () => {
-      component['filterByFavorite'](true);
-      expect(component['addQueryParam']).toHaveBeenCalledWith({ favoriteOrders: true })
-    });
-    it('should show all products when false', () => {
-      component['filterByFavorite'](false);
-      expect(component['addQueryParam']).toHaveBeenCalledWith({ favoriteOrders: undefined })
+    describe('result', () => {
+      const queryParamWithFavorites = convertToParamMap({
+        favoriteOrders: 'true',
+      });
+      const queryParamWithoutFavorites = convertToParamMap({
+        someParam: 'blah',
+      });
+      it('should be undefined if query param does not include "favoriteOrders"', () => {
+        spyOn(favoriteOrdersService, 'getFavorites').and.returnValue(['ID1']);
+        const result = component['buildFavoriteOrdersQuery'](
+          queryParamWithoutFavorites
+        );
+        expect(result).toBeUndefined();
+      });
+      it('should be undefined if favorites array has a length of 0', () => {
+        spyOn(favoriteOrdersService, 'getFavorites').and.returnValue([]);
+        const result = component['buildFavoriteOrdersQuery'](
+          queryParamWithFavorites
+        );
+        expect(result).toBeUndefined();
+      });
+      it('should be defined if "favoriteOrders" query param is "true" and favorites array has values', () => {
+        spyOn(favoriteOrdersService, 'getFavorites').and.returnValue([
+          'ID1',
+          'ID2',
+        ]);
+        const result = component['buildFavoriteOrdersQuery'](
+          queryParamWithFavorites
+        );
+        expect(result).toBe('ID1|ID2');
+      });
     });
   });
 });

--- a/src/UI/Buyer/src/app/order/containers/order/order.component.spec.ts
+++ b/src/UI/Buyer/src/app/order/containers/order/order.component.spec.ts
@@ -3,7 +3,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { OrderComponent } from '@app-buyer/order/containers/order/order.component';
 import { RouterTestingModule } from '@angular/router/testing';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
-import { Subject, of } from 'rxjs';
+import { Subject } from 'rxjs';
 import { ActivatedRoute } from '@angular/router';
 import { FavoriteOrdersService } from '@app-buyer/shared/services/favorites/favorites.service';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
@@ -14,17 +14,13 @@ describe('OrderComponent', () => {
   const dataSubject = new Subject<any>();
   const activatedRoute = { data: dataSubject };
 
-  const favoriteOrdersService = {
-    loadFavorites: jasmine.createSpy('loadFavorites').and.returnValue(of(null)),
-  };
-
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [FaIconComponent, OrderComponent],
       imports: [RouterTestingModule],
       providers: [
         { provide: ActivatedRoute, useValue: activatedRoute },
-        { provide: FavoriteOrdersService, useValue: favoriteOrdersService },
+        { provide: FavoriteOrdersService, useValue: {} },
       ],
       schemas: [NO_ERRORS_SCHEMA], // Ignore template errors: remove if tests are added to test template
     }).compileComponents();
@@ -49,9 +45,6 @@ describe('OrderComponent', () => {
         expect(order).toEqual({ ID: 'mockOrderID' });
       });
       dataSubject.next({ orderResolve: { order: { ID: 'mockOrderID' } } });
-    });
-    it('should load favorites', () => {
-      expect(favoriteOrdersService.loadFavorites).toHaveBeenCalled();
     });
   });
 });

--- a/src/UI/Buyer/src/app/order/containers/order/order.component.ts
+++ b/src/UI/Buyer/src/app/order/containers/order/order.component.ts
@@ -18,11 +18,10 @@ export class OrderComponent implements OnInit {
 
   constructor(
     private activatedRoute: ActivatedRoute,
-    private favoriteOrdersService: FavoriteOrdersService
+    protected favoriteOrdersService: FavoriteOrdersService // used in template
   ) {}
 
   ngOnInit() {
-    this.favoriteOrdersService.loadFavorites();
     this.order$ = this.activatedRoute.data.pipe(
       map(({ orderResolve }) => orderResolve.order)
     );

--- a/src/UI/Buyer/src/app/products/components/additional-image-gallery/additional-image-gallery.component.ts
+++ b/src/UI/Buyer/src/app/products/components/additional-image-gallery/additional-image-gallery.component.ts
@@ -1,15 +1,14 @@
 import { takeWhile } from 'rxjs/operators';
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnInit, OnDestroy } from '@angular/core';
 import { faAngleLeft, faAngleRight } from '@fortawesome/free-solid-svg-icons';
 import { fromEvent } from 'rxjs';
-
 
 @Component({
   selector: 'products-additional-image-gallery',
   templateUrl: './additional-image-gallery.component.html',
   styleUrls: ['./additional-image-gallery.component.scss'],
 })
-export class AdditionalImageGalleryComponent implements OnInit {
+export class AdditionalImageGalleryComponent implements OnInit, OnDestroy {
   // gallerySize can be changed and the component logic + behavior will all work. However, the UI may look wonky.
   private readonly gallerySize = 5;
   private alive = true;
@@ -34,7 +33,7 @@ export class AdditionalImageGalleryComponent implements OnInit {
       )
       .subscribe(() => {
         this.onResize();
-      })
+      });
   }
 
   onResize() {

--- a/src/UI/Buyer/src/app/products/components/sort-filter/sort-filter.component.html
+++ b/src/UI/Buyer/src/app/products/components/sort-filter/sort-filter.component.html
@@ -1,0 +1,15 @@
+<form [formGroup]="form">
+  <div class="form-group float-right">
+    <select class="form-control"
+            formControlName="strategy"
+            (change)="sortStrategyChanged()">
+      <option [ngValue]="null"
+              disabled>None</option>
+      <option [ngValue]="option.key"
+              *ngFor="let option of options | mapToIterable">
+        {{ option.value }}
+      </option>
+    </select>
+  </div>
+  <div class="float-right mt-1 mr-2">Sort By</div>
+</form>

--- a/src/UI/Buyer/src/app/products/components/sort-filter/sort-filter.component.spec.ts
+++ b/src/UI/Buyer/src/app/products/components/sort-filter/sort-filter.component.spec.ts
@@ -1,0 +1,48 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SortFilterComponent } from './sort-filter.component';
+import { ReactiveFormsModule } from '@angular/forms';
+import { MapToIterablePipe } from '@app-buyer/shared/pipes/map-to-iterable/map-to-iterable.pipe';
+
+describe('SortFilterComponent', () => {
+  let component: SortFilterComponent;
+  let fixture: ComponentFixture<SortFilterComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [SortFilterComponent, MapToIterablePipe],
+      imports: [ReactiveFormsModule],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SortFilterComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('ngOnInit', () => {
+    beforeEach(() => {
+      spyOn(component as any, 'setForm');
+      component.ngOnInit();
+    });
+    it('should set the form', () => {
+      expect(component['setForm']).toHaveBeenCalled();
+    });
+  });
+
+  describe('sortStrategyChanged', () => {
+    beforeEach(() => {
+      spyOn(component.sortStrategyChange, 'emit');
+      component.form.controls['strategy'].setValue('!ID');
+      component['sortStrategyChanged']();
+    });
+    it('should emit sort strategy from form', () => {
+      expect(component.sortStrategyChange.emit).toHaveBeenCalledWith('!ID');
+    });
+  });
+});

--- a/src/UI/Buyer/src/app/products/components/sort-filter/sort-filter.component.ts
+++ b/src/UI/Buyer/src/app/products/components/sort-filter/sort-filter.component.ts
@@ -1,0 +1,32 @@
+import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
+import { FormGroup, FormBuilder } from '@angular/forms';
+import { ProductSortStrategy } from '@app-buyer/products/models/product-sort-strategy.enum';
+
+@Component({
+  selector: 'products-sort-filter',
+  templateUrl: './sort-filter.component.html',
+  styleUrls: ['./sort-filter.component.scss'],
+})
+export class SortFilterComponent implements OnInit {
+  form: FormGroup;
+  options = ProductSortStrategy;
+  @Input() sortStrategy?: string;
+  @Output() sortStrategyChange = new EventEmitter<ProductSortStrategy>();
+
+  constructor(private formBuilder: FormBuilder) {}
+
+  ngOnInit() {
+    this.setForm();
+  }
+
+  private setForm() {
+    this.form = this.formBuilder.group({
+      strategy: this.options[this.sortStrategy],
+    });
+  }
+
+  protected sortStrategyChanged() {
+    const sortStrategy = this.form.get('strategy').value;
+    this.sortStrategyChange.emit(sortStrategy);
+  }
+}

--- a/src/UI/Buyer/src/app/products/containers/product-details/product-details.component.html
+++ b/src/UI/Buyer/src/app/products/containers/product-details/product-details.component.html
@@ -12,8 +12,8 @@
       <span class="ml-3">
         <shared-toggle-favorite title="Favorite"
                                 (click)="$event.stopPropagation()"
-                                [favorite]="favoriteProductsService.isFavorite(product)"
-                                (favoriteChanged)="favoriteProductsService.setFavoriteValue($event, product)">
+                                [favorite]="favoriteProductService.isFavorite(product)"
+                                (favoriteChanged)="favoriteProductService.setFavoriteValue($event, product)">
         </shared-toggle-favorite>
       </span>
       <hr>
@@ -58,8 +58,10 @@
           <ngb-tab>
             <ng-template ngbTabTitle>Specs</ng-template>
             <ng-template ngbTabContent>
-              <p class="mt-4">Food truck fixie locavore, accusamus mcsweeney's marfa nulla single-origin coffee squid. Exercitation +1 labore velit, blog sartorial PBR leggings next level wes anderson artisan four loko farm-to-table craft beer twee. Qui photo booth letterpress,
-                commodo enim craft beer mlkshk aliquip jean shorts ullamco ad vinyl cillum PBR. Homo nostrud organic, assumenda labore aesthetic magna delectus mollit. Keytar helvetica VHS salvia yr, vero magna velit sapiente labore stumptown. Vegan fanny
+              <p class="mt-4">Food truck fixie locavore, accusamus mcsweeney's marfa nulla single-origin coffee squid. Exercitation +1 labore velit, blog sartorial PBR leggings next level wes anderson artisan four loko farm-to-table craft beer twee.
+                Qui photo booth letterpress,
+                commodo enim craft beer mlkshk aliquip jean shorts ullamco ad vinyl cillum PBR. Homo nostrud organic, assumenda labore aesthetic magna delectus mollit. Keytar helvetica VHS salvia yr, vero magna velit sapiente labore stumptown. Vegan
+                fanny
                 pack odio cillum wes anderson 8-bit, sustainable jean shorts beard ut DIY ethical culpa terry richardson biodiesel. Art party scenester stumptown, tumblr butcher vero sint qui sapiente accusamus tattooed echo park.</p>
             </ng-template>
           </ngb-tab>

--- a/src/UI/Buyer/src/app/products/containers/product-details/product-details.component.spec.ts
+++ b/src/UI/Buyer/src/app/products/containers/product-details/product-details.component.spec.ts
@@ -52,8 +52,7 @@ describe('ProductDetailsComponent', () => {
     create: jasmine.createSpy('create').and.returnValue(of(null)),
   };
   const favoriteProductsService = {
-    loadFavorites: jasmine.createSpy('loadFavorites'),
-    isFavorite: jasmine.createSpy('isFavorite').and.returnValue(true),
+    isFavorite: () => jasmine.createSpy('isFavorite').and.returnValue(true),
   };
 
   beforeEach(async(() => {
@@ -71,7 +70,10 @@ describe('ProductDetailsComponent', () => {
         OcLineItemService,
         { provide: OcMeService, useValue: meService },
         { provide: AppLineItemService, useValue: ocLineItemService },
-        { provide: FavoriteProductsService, useValue: favoriteProductsService },
+        {
+          provide: FavoriteProductsService,
+          useValue: favoriteProductsService,
+        },
         OcOrderService,
         RouterTestingModule,
         OcTokenService,
@@ -100,9 +102,6 @@ describe('ProductDetailsComponent', () => {
     });
     it('should call getProductData', () => {
       expect(component.getProductData).toHaveBeenCalled();
-    });
-    it('should load favorites', () => {
-      expect(favoriteProductsService.loadFavorites).toHaveBeenCalled();
     });
   });
 

--- a/src/UI/Buyer/src/app/products/containers/product-details/product-details.component.ts
+++ b/src/UI/Buyer/src/app/products/containers/product-details/product-details.component.ts
@@ -32,14 +32,13 @@ export class ProductDetailsComponent implements OnInit, AfterViewChecked {
     private ocMeService: OcMeService,
     private activatedRoute: ActivatedRoute,
     private appLineItemService: AppLineItemService,
-    private favoriteProductsService: FavoriteProductsService,
     private appStateService: AppStateService,
-    private changeDetectorRef: ChangeDetectorRef
+    private changeDetectorRef: ChangeDetectorRef,
+    protected favoriteProductService: FavoriteProductsService // used in template
   ) {}
 
   ngOnInit(): void {
     this.getProductData().subscribe((x) => (this.product = x));
-    this.favoriteProductsService.loadFavorites();
   }
 
   getProductData(): Observable<BuyerProduct> {

--- a/src/UI/Buyer/src/app/products/containers/product-list/product-list.component.html
+++ b/src/UI/Buyer/src/app/products/containers/product-list/product-list.component.html
@@ -44,26 +44,14 @@
         <div class="col-auto">
           <div class="m-0 mt-1">
             <span *ngIf="productList.Meta.TotalPages > 1">
-              {{ ((productList.Meta.Page - 1) * productList.Meta.PageSize) + 1 }} - {{productList.Meta.Page * productList.Meta.PageSize}} of
+              {{ ((productList.Meta.Page - 1) * productList.Meta.PageSize) + 1 }} - {{productList.Meta.Page * productList.Meta.PageSize}}
+              of
             </span>{{productList.Meta.TotalCount}} results
           </div>
         </div>
         <div class="col-auto">
-          <form [formGroup]="sortForm">
-            <div class="form-group float-right">
-              <select class="form-control"
-                      formControlName="sortBy"
-                      (change)="sortStratChanged()">
-                <option [ngValue]="null"
-                        disabled>None</option>
-                <option [ngValue]="sortOption.key"
-                        *ngFor="let sortOption of sortOptions | mapToIterable">
-                  {{ sortOption.value }}
-                </option>
-              </select>
-            </div>
-            <div class="float-right mt-1 mr-2">Sort By</div>
-          </form>
+          <products-sort-filter [sortStrategy]="activatedRoute.queryParams.sortBy"
+                                (sortStrategyChange)="changeSortStrategy($event)"></products-sort-filter>
         </div>
       </div>
       <div class="card"

--- a/src/UI/Buyer/src/app/products/index.ts
+++ b/src/UI/Buyer/src/app/products/index.ts
@@ -6,4 +6,4 @@ export * from '@app-buyer/products/containers/product-details/product-details.co
 export * from '@app-buyer/products/components/additional-image-gallery/additional-image-gallery.component';
 
 // models
-export * from '@app-buyer/products/models/product-sort-strats.enum';
+export * from '@app-buyer/products/models/product-sort-strategy.enum';

--- a/src/UI/Buyer/src/app/products/models/product-sort-strategy.enum.ts
+++ b/src/UI/Buyer/src/app/products/models/product-sort-strategy.enum.ts
@@ -1,4 +1,4 @@
-export enum ProductSortStrats {
+export enum ProductSortStrategy {
   'ID' = 'ID: A to Z',
   '!ID' = 'ID: Z to A',
   'Name' = 'Name: A to Z',

--- a/src/UI/Buyer/src/app/products/products.module.ts
+++ b/src/UI/Buyer/src/app/products/products.module.ts
@@ -9,6 +9,7 @@ import { AdditionalImageGalleryComponent } from '@app-buyer/products/components/
 import { ImageZoomModule } from 'angular2-image-zoom';
 import { PriceFilterComponent } from '@app-buyer/products/components/price-filter/price-filter.component';
 import { CategoryNavComponent } from '@app-buyer/products/components/category-nav/category-nav.component';
+import { SortFilterComponent } from './components/sort-filter/sort-filter.component';
 
 @NgModule({
   imports: [SharedModule, ProductsRoutingModule, ImageZoomModule, TreeModule],
@@ -18,6 +19,7 @@ import { CategoryNavComponent } from '@app-buyer/products/components/category-na
     AdditionalImageGalleryComponent,
     PriceFilterComponent,
     CategoryNavComponent,
+    SortFilterComponent,
   ],
 })
 export class ProductsModule {}

--- a/src/UI/Buyer/src/app/shared/services/favorites/favorites.service.spec.ts
+++ b/src/UI/Buyer/src/app/shared/services/favorites/favorites.service.spec.ts
@@ -6,7 +6,6 @@ import { FavoriteProductsService } from '@app-buyer/shared/services/favorites/fa
 import { AppStateService } from '@app-buyer/shared/services/app-state/app-state.service';
 
 describe('FavoriteProductsService', () => {
-
   let service;
   const meService = {
     Get: jasmine.createSpy('Get').and.returnValue(of({})),
@@ -15,8 +14,10 @@ describe('FavoriteProductsService', () => {
       .and.returnValue(of({ xp: { FavoriteProducts: [] } })),
   };
   const appStateService = {
-    userSubject: new BehaviorSubject<MeUser>({ xp: { 'FavoriteProducts': ['Id1', 'Id2'] } })
-  }
+    userSubject: new BehaviorSubject<MeUser>({
+      xp: { FavoriteProducts: ['Id1', 'Id2'] },
+    }),
+  };
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -31,37 +32,60 @@ describe('FavoriteProductsService', () => {
 
   it('should be created', () => {
     expect(service).toBeTruthy();
-  })
+  });
 
-  it('isProductFav should return true for a favorite', () => {
-    service.favorites = ['a', 'b', 'c'];
-    expect(service.isFavorite({ ID: 'a' })).toEqual(true);
-  }
-  );
-
-  it('isProductFav should return false for a non-favorite', () => {
-    service.favorites = ['a', 'b', 'c'];
-    expect(service.isFavorite({ ID: 'd' })).toEqual(false);
-  }
-  );
-
-  it('setProductAsFav should remove fav correctly', () => {
-    meService.Patch.calls.reset();
-    service.favorites = ['a', 'b'];
-    service.setFavoriteValue(false, { ID: 'a' });
-    expect(meService.Patch).toHaveBeenCalledWith({
-      xp: { FavoriteProducts: ['b'] },
+  describe('isFavorite', () => {
+    it('should return true if product is in favorites array', () => {
+      spyOn(service, 'getFavorites').and.returnValue(['a', 'b', 'c']);
+      expect(service.isFavorite({ ID: 'a' })).toEqual(true);
     });
-  }
-  );
-
-  it('setProductAsFav should add fav correctly', () => {
-    meService.Patch.calls.reset();
-    service.favorites = ['a', 'b'];
-    service.setFavoriteValue(true, { ID: 'c' });
-    expect(meService.Patch).toHaveBeenCalledWith({
-      xp: { FavoriteProducts: ['a', 'b', 'c'] },
+    it('should return false if product is not in favorites array', () => {
+      spyOn(service, 'getFavorites').and.returnValue(['a', 'b', 'c']);
+      expect(service.isFavorite({ ID: 'd' })).toEqual(false);
     });
-  }
-  );
+  });
+
+  describe('setFavoriteValue', () => {
+    it('should remove fav correctly', () => {
+      meService.Patch.calls.reset();
+      spyOn(service, 'getFavorites').and.returnValue(['a', 'b']);
+      service.setFavoriteValue(false, { ID: 'a' });
+      expect(meService.Patch).toHaveBeenCalledWith({
+        xp: { FavoriteProducts: ['b'] },
+      });
+    });
+    it('should add fav correctly', () => {
+      meService.Patch.calls.reset();
+      spyOn(service, 'getFavorites').and.returnValue(['a', 'b']);
+      service.setFavoriteValue(true, { ID: 'c' });
+      expect(meService.Patch).toHaveBeenCalledWith({
+        xp: { FavoriteProducts: ['a', 'b', 'c'] },
+      });
+    });
+  });
+
+  describe('getFavorites', () => {
+    it('should return an empty array if me.xp is not defined', () => {
+      appStateService.userSubject.next(<MeUser>{ xp: undefined });
+      expect(service.getFavorites()).toEqual([]);
+    });
+    it('should return an empty array if me.xp.XpFieldName is undefined', () => {
+      appStateService.userSubject.next(<MeUser>{
+        xp: { FavoriteProducts: undefined },
+      });
+      expect(service.getFavorites()).toEqual([]);
+    });
+    it('should return an empty array if me.xp.XpFieldName is a string', () => {
+      appStateService.userSubject.next(<MeUser>{
+        xp: { FavoriteProducts: 'not an array' },
+      });
+      expect(service.getFavorites()).toEqual([]);
+    });
+    it('should return me.xp.XpFieldName if it is a non-empty array', () => {
+      appStateService.userSubject.next(<MeUser>{
+        xp: { FavoriteProducts: ['IDOne', 'IDTwo'] },
+      });
+      expect(service.getFavorites()).toEqual(['IDOne', 'IDTwo']);
+    });
+  });
 });

--- a/src/UI/Buyer/src/app/shared/services/favorites/favorites.service.ts
+++ b/src/UI/Buyer/src/app/shared/services/favorites/favorites.service.ts
@@ -32,9 +32,7 @@ abstract class FavoritesService<T extends { ID?: string }> {
 
   getFavorites(): string[] {
     const me = this.appStateService.userSubject.value;
-    return me.xp &&
-      me.xp[this.XpFieldName] &&
-      me.xp[this.XpFieldName] instanceof Array
+    return me.xp && me.xp[this.XpFieldName] instanceof Array
       ? me.xp[this.XpFieldName]
       : [];
   }

--- a/src/UI/Buyer/src/app/shared/services/favorites/favorites.service.ts
+++ b/src/UI/Buyer/src/app/shared/services/favorites/favorites.service.ts
@@ -34,7 +34,6 @@ abstract class FavoritesService<T extends { ID?: string }> {
     const me = this.appStateService.userSubject.value;
     return me.xp &&
       me.xp[this.XpFieldName] &&
-      me.xp[this.XpFieldName] &&
       me.xp[this.XpFieldName] instanceof Array
       ? me.xp[this.XpFieldName]
       : [];

--- a/src/UI/Buyer/src/app/shared/services/favorites/favorites.service.ts
+++ b/src/UI/Buyer/src/app/shared/services/favorites/favorites.service.ts
@@ -1,50 +1,43 @@
 import { Injectable, Inject } from '@angular/core';
-import {
-  OcMeService,
-  BuyerProduct,
-  Order,
-  MeUser,
-} from '@ordercloud/angular-sdk';
+import { OcMeService, BuyerProduct, Order } from '@ordercloud/angular-sdk';
 import { AppStateService } from '@app-buyer/shared';
 
 abstract class FavoritesService<T extends { ID?: string }> {
   protected readonly XpFieldName: string;
 
-  // Array of object IDs
-  public favorites: string[] = null;
-
   constructor(
     private appStateService: AppStateService,
     private ocMeService: OcMeService
-  ) { }
-
-  loadFavorites(): void {
-    if (this.favorites !== null) {
-      return;
-    }
-
-    this.appStateService.userSubject.subscribe((me: MeUser) => {
-      this.favorites =
-        me.xp && me.xp[this.XpFieldName] ? me.xp[this.XpFieldName] : [];
-    });
-  }
+  ) {}
 
   isFavorite(object: T): boolean {
-    return this.favorites !== null && this.favorites.indexOf(object.ID) > -1;
+    const favorites = this.getFavorites();
+    return favorites.includes(object.ID);
   }
 
   setFavoriteValue(isFav: boolean, object: T): void {
+    const favorites = this.getFavorites();
+    let updatedFavorites: string[];
     if (isFav) {
-      this.favorites.push(object.ID);
+      updatedFavorites = [...favorites, object.ID];
     } else {
-      this.favorites = this.favorites.filter((x) => x !== object.ID);
+      updatedFavorites = favorites.filter((x) => x !== object.ID);
     }
     const request = { xp: {} };
-    request.xp[this.XpFieldName] = this.favorites;
+    request.xp[this.XpFieldName] = updatedFavorites;
     this.ocMeService.Patch(request).subscribe((me) => {
       this.appStateService.userSubject.next(me);
-      this.favorites = me.xp[this.XpFieldName];
     });
+  }
+
+  getFavorites(): string[] {
+    const me = this.appStateService.userSubject.value;
+    return me.xp &&
+      me.xp[this.XpFieldName] &&
+      me.xp[this.XpFieldName] &&
+      me.xp[this.XpFieldName] instanceof Array
+      ? me.xp[this.XpFieldName]
+      : [];
   }
 }
 

--- a/src/UI/Buyer/src/polyfills.ts
+++ b/src/UI/Buyer/src/polyfills.ts
@@ -33,6 +33,7 @@ import 'core-js/es6/regexp';
 import 'core-js/es6/map';
 import 'core-js/es6/weak-map';
 import 'core-js/es6/set';
+import 'core-js/es7/array';
 
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.
@@ -58,13 +59,6 @@ import 'zone.js/dist/zone'; // Included with Angular CLI.
 /***************************************************************************************************
  * APPLICATION IMPORTS
  */
-
-/**
- * The following is required by algoliasearch-client-javascript,
- * which was broken by angular v6:
- * https://github.com/algolia/algoliasearch-client-javascript/issues/691
- */
-(window as any).process = { env: {} };
 
 /**
  * this polyfill is to allow us to use avatax clientside


### PR DESCRIPTION
# Description

- Sort Filter component - this was abstracted out from product list into a dumb component
- Update Favorites service so that loading favorites is not required. This was originally doing a Me.Get to check favorite products and it had to be loaded in the service it was used. I'm now getting info from the user subject which gets loaded in the base app once so loading it is no longer necessary. This lead to fixing tests in a lot of places that it was used
- added polyfill for internet explorer to support 'includes'. Its a lot more expressive to use this than indexOf and I thought it made a good addition. Its also one that people forget isn't supported by IE so less chance of us breaking IE

## Type of change
- [x ] Refactor (change/optimize code without changing external behavior)

# Checklist:

- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [ ] I have updated the acceptance criteria on the task so that it can be tested
