### PR TITLE
fix: validate password correctly during forgot password flow #143

### DIFF
--- a/src/UI/Buyer/src/app/auth/containers/forgot-password/forgot-password.component.spec.ts
+++ b/src/UI/Buyer/src/app/auth/containers/forgot-password/forgot-password.component.spec.ts
@@ -81,7 +81,8 @@ describe('ForgotPasswordComponent', () => {
         URL: 'http://localhost:9876',
       });
       expect(toastrService.success).toHaveBeenCalledWith(
-        'Password Reset Email Sent!'
+        'Password Reset Email Sent!',
+        'Success'
       );
       expect(router.navigateByUrl).toHaveBeenCalledWith('/login');
     });

--- a/src/UI/Buyer/src/app/auth/containers/forgot-password/forgot-password.component.ts
+++ b/src/UI/Buyer/src/app/auth/containers/forgot-password/forgot-password.component.ts
@@ -42,7 +42,7 @@ export class ForgotPasswordComponent implements OnInit {
       })
       .subscribe(
         () => {
-          this.toasterService.success('Password Reset Email Sent!');
+          this.toasterService.success('Password Reset Email Sent!', 'Success');
           this.router.navigateByUrl('/login');
         },
         (error) => {

--- a/src/UI/Buyer/src/app/auth/containers/reset-password/reset-password.component.html
+++ b/src/UI/Buyer/src/app/auth/containers/reset-password/reset-password.component.html
@@ -6,7 +6,7 @@
        style="max-width:350px;">
     <h3 class="text-center text-muted mb-3">New Password</h3>
     <form (ngSubmit)="onSubmit()"
-          [formGroup]="resetPasswordForm"
+          [formGroup]="form"
           name="NewPassword"
           autocomplete="off"
           novalidate>
@@ -20,6 +20,13 @@
                placeholder="Password"
                autocapitalize="off"
                autofocus />
+        <span *ngIf="hasRequiredError('password')"
+              class="error-message">Password is required</span>
+        <span *ngIf="hasStrongPasswordError('password')"
+              class="error-message">Password must
+          be at least eight characters long and include at least one letter and one number. Password can also include special
+          characters.
+        </span>
       </div>
       <div class="form-group">
         <label for="confirm"
@@ -31,9 +38,11 @@
                placeholder="Confirm Password"
                autocapitalize="off"
                autofocus />
+        <span *ngIf="hasRequiredError('passwordConfirm')"
+              class="error-message">Confirm Password is required</span>
+        <span *ngIf="hasPasswordMismatchError()"
+              class="error-message">Passwords must match</span>
       </div>
-      <span *ngIf="passwordMismatchError()"
-            class="error-message">Passwords must match</span>
       <button id="submitBtn"
               type="submit"
               class="btn btn-primary btn-block">Set New Password</button>

--- a/src/UI/Buyer/src/app/auth/containers/reset-password/reset-password.component.spec.ts
+++ b/src/UI/Buyer/src/app/auth/containers/reset-password/reset-password.component.spec.ts
@@ -35,6 +35,8 @@ describe('ResetPasswordComponent', () => {
   };
   const formErrorService = {
     hasPasswordMismatchError: jasmine.createSpy('hasPasswordMismatchError'),
+    hasRequiredError: jasmine.createSpy('hasRequiredError'),
+    hasStrongPasswordError: jasmine.createSpy('hasStrongPasswordError'),
   };
 
   beforeEach(async(() => {
@@ -66,12 +68,11 @@ describe('ResetPasswordComponent', () => {
     expect(component).toBeTruthy();
   });
   describe('ngOnInit', () => {
-    const formbuilder = new FormBuilder();
     beforeEach(() => {
       component.ngOnInit();
     });
     it('should set the form values to empty strings, and the local vars to the matching query params', () => {
-      expect(component.resetPasswordForm.value).toEqual({
+      expect(component.form.value).toEqual({
         password: '',
         passwordConfirm: '',
       });
@@ -85,32 +86,66 @@ describe('ResetPasswordComponent', () => {
   });
   describe('onSubmit', () => {
     beforeEach(() => {
+      setValidForm();
       component['appConfig'].clientID = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
-
       component.onSubmit();
     });
-    it('should call the PasswordService ResetPasswordByVerificationCode method, Toastr success method, and route to login', () => {
+    it('should call ResetPasswordByVerificationCode', () => {
       expect(
         ocPasswordService.ResetPasswordByVerificationCode
       ).toHaveBeenCalledWith('pwverificationcode', {
         ClientID: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
-        Password: component.resetPasswordForm.value.password,
+        Password: component.form.value.password,
         Username: component.username,
       });
+    });
+    it('should call success toastr', () => {
       expect(toastrService.success).toHaveBeenCalledWith(
-        'Password Reset Successfully'
+        'Password Reset',
+        'Success'
       );
+    });
+    it('should route user to login', () => {
       expect(router.navigateByUrl).toHaveBeenCalledWith('/login');
     });
   });
 
-  describe('passwordMismatchError', () => {
+  function setValidForm() {
+    component.form.controls['password'].setValue('fails345');
+    component.form.controls['passwordConfirm'].setValue('fails345');
+  }
+
+  describe('hasRequiredError', () => {
     beforeEach(() => {
-      component['passwordMismatchError']();
+      component['hasRequiredError']('password');
+    });
+    it('should call formErrorService.hasRequiredError', () => {
+      expect(formErrorService.hasRequiredError).toHaveBeenCalledWith(
+        'password',
+        component.form
+      );
+    });
+  });
+
+  describe('hasPasswordMismatchError', () => {
+    beforeEach(() => {
+      component['hasPasswordMismatchError']();
     });
     it('should call formErrorService.hasRequiredError', () => {
       expect(formErrorService.hasPasswordMismatchError).toHaveBeenCalledWith(
-        component.resetPasswordForm
+        component.form
+      );
+    });
+  });
+
+  describe('hasStrongPasswordError', () => {
+    beforeEach(() => {
+      component['hasStrongPasswordError']('password');
+    });
+    it('should call formErrorService.hasStrongPasswordError', () => {
+      expect(formErrorService.hasStrongPasswordError).toHaveBeenCalledWith(
+        'password',
+        component.form
       );
     });
   });

--- a/src/UI/Buyer/src/app/order/components/order-list/order-list.component.html
+++ b/src/UI/Buyer/src/app/order/components/order-list/order-list.component.html
@@ -49,8 +49,8 @@
           [routerLink]="[ order.ID ]">
         <td *ngIf="columns.indexOf('Favorite') > -1"
             (click)="$event.stopPropagation()">
-          <shared-toggle-favorite [favorite]="favoriteOrdersService.isFavorite(order)"
-                                  (favoriteChanged)="favoriteOrdersService.setFavoriteValue($event, order)">
+          <shared-toggle-favorite [favorite]="favoriteOrderService.isFavorite(order)"
+                                  (favoriteChanged)="favoriteOrderService.setFavoriteValue($event, order)">
           </shared-toggle-favorite>
         </td>
         <td *ngIf="columns.indexOf('ID')> -1">{{order.ID}}</td>

--- a/src/UI/Buyer/src/app/order/components/order-list/order-list.component.spec.ts
+++ b/src/UI/Buyer/src/app/order/components/order-list/order-list.component.spec.ts
@@ -12,6 +12,7 @@ import {
   NgbDateCustomParserFormatter,
 } from '@app-buyer/config/date-picker.config';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { FavoriteOrdersService } from '@app-buyer/shared/services/favorites/favorites.service';
 
 describe('OrderListComponent', () => {
   let component: OrderListComponent;
@@ -27,6 +28,7 @@ describe('OrderListComponent', () => {
           provide: NgbDateParserFormatter,
           useClass: NgbDateCustomParserFormatter,
         },
+        { provide: FavoriteOrdersService, useValue: {} },
       ],
       schemas: [NO_ERRORS_SCHEMA], // Ignore template errors: remove if tests are added to test template
     }).compileComponents();

--- a/src/UI/Buyer/src/app/order/components/order-list/order-list.component.ts
+++ b/src/UI/Buyer/src/app/order/components/order-list/order-list.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, EventEmitter, Output } from '@angular/core';
 import { ListOrder } from '@ordercloud/angular-sdk';
 import { OrderListColumn } from '@app-buyer/order/models/order-list-column';
 import { faCaretDown, faCaretUp } from '@fortawesome/free-solid-svg-icons';
+import { FavoriteOrdersService } from '@app-buyer/shared/services/favorites/favorites.service';
 
 @Component({
   selector: 'order-list',
@@ -17,7 +18,9 @@ export class OrderListComponent {
   @Output() updatedSort = new EventEmitter<string>();
   @Output() changedPage = new EventEmitter<number>();
 
-  constructor() {}
+  constructor(
+    protected favoriteOrderService: FavoriteOrdersService // used in template
+  ) {}
 
   protected updateSort(selectedSortBy) {
     let sortBy;

--- a/src/UI/Buyer/src/app/shared/components/change-password-form/change-password-form.component.html
+++ b/src/UI/Buyer/src/app/shared/components/change-password-form/change-password-form.component.html
@@ -1,28 +1,52 @@
-<form (ngSubmit)="updatePassword()" novalidate [formGroup]="form" name="form">
+<form (ngSubmit)="updatePassword()"
+      novalidate
+      [formGroup]="form"
+      name="form">
   <div class="modal-body">
-    <label for="currentPassword" class="sr-only">Current Password</label>
     <div class="form-group">
-      <input formControlName="currentPassword" id="currentPassword" class="form-control" type="password" placeholder="Current Password"
-        autocomplete="off" />
-      <span *ngIf="hasRequiredError('currentPassword')" class="error-message">Current Password is required</span>
+      <label for="currentPassword"
+             class="sr-only">Current Password</label>
+      <input formControlName="currentPassword"
+             id="currentPassword"
+             class="form-control"
+             type="password"
+             placeholder="Current Password"
+             autocomplete="off" />
+      <span *ngIf="hasRequiredError('currentPassword')"
+            class="error-message">Current Password is required</span>
     </div>
-    <label for="newPassword" class="sr-only">New Password</label>
     <div class="form-group">
-      <input formControlName="newPassword" id="newPassword" class="form-control" type="password" placeholder="New Password" autocomplete="off"
-      />
-      <span *ngIf="hasRequiredError('newPassword')" class="error-message">New Password is required</span>
-      <span *ngIf="hasPatternError('newPassword') || hasMinLengthError('newPassword')" class="error-message">Password must
+      <label for="newPassword"
+             class="sr-only">New Password</label>
+      <input formControlName="newPassword"
+             id="newPassword"
+             class="form-control"
+             type="password"
+             placeholder="New Password"
+             autocomplete="off" />
+      <span *ngIf="hasRequiredError('newPassword')"
+            class="error-message">New Password is required</span>
+      <span *ngIf="hasStrongPasswordError('newPassword')"
+            class="error-message">Password must
         be at least eight characters long and include at least one letter and one number. Password can also include special
         characters.
       </span>
     </div>
-    <label for="confirmNewPassword" class="sr-only">Confirm New Password</label>
     <div class="form-group">
-      <input formControlName="confirmNewPassword" id="confirmNewPassword" class="form-control" type="password" placeholder="Confirm New Password"
-        autocomplete="off" />
-      <span *ngIf="hasRequiredError('confirmNewPassword')" class="error-message">Confirm New Password is required</span>
-      <span *ngIf="hasPasswordMismatchError()" class="error-message">Passwords must match</span>
+      <label for="confirmNewPassword"
+             class="sr-only">Confirm New Password</label>
+      <input formControlName="confirmNewPassword"
+             id="confirmNewPassword"
+             class="form-control"
+             type="password"
+             placeholder="Confirm New Password"
+             autocomplete="off" />
+      <span *ngIf="hasRequiredError('confirmNewPassword')"
+            class="error-message">Confirm New Password is required</span>
+      <span *ngIf="hasPasswordMismatchError()"
+            class="error-message">Passwords must match</span>
     </div>
   </div>
-  <button type="submit" class="btn btn-primary btn-block">Save</button>
+  <button type="submit"
+          class="btn btn-primary btn-block">Save</button>
 </form>

--- a/src/UI/Buyer/src/app/shared/components/change-password-form/change-password-form.component.spec.ts
+++ b/src/UI/Buyer/src/app/shared/components/change-password-form/change-password-form.component.spec.ts
@@ -11,8 +11,7 @@ describe('ChangePasswordFormComponent', () => {
     displayFormErrors: jasmine.createSpy('displayFormErrors'),
     hasRequiredError: jasmine.createSpy('hasRequiredError'),
     hasPasswordMismatchError: jasmine.createSpy('hasPasswordMismatchError'),
-    hasPatternError: jasmine.createSpy('hasPatternError'),
-    hasMinLengthError: jasmine.createSpy('hasMinLengthError'),
+    hasStrongPasswordError: jasmine.createSpy('hasStrongPasswordError'),
   };
 
   beforeEach(async(() => {
@@ -96,19 +95,5 @@ describe('ChangePasswordFormComponent', () => {
         expect(component.form.reset).toHaveBeenCalled();
       });
     });
-
-    describe('new password validation', () => {
-      beforeEach(() => {
-        component.form.controls.currentPassword.setValue('valid password');
-      })
-      it('should be valid when there are > 8 characters, one number, one letter', () => {
-        component.form.controls.newPassword.setValue('fails345');
-        component.form.controls.confirmNewPassword.setValue('fails345');
-      })
-      it('should be invalid if there are fewer than 8 characters', () => {
-        component.form.controls.newPassword.setValue('fails345');
-        component.form.controls.confirmNewPassword.setValue('fails345');
-      })
-    })
   });
 });

--- a/src/UI/Buyer/src/app/shared/components/change-password-form/change-password-form.component.ts
+++ b/src/UI/Buyer/src/app/shared/components/change-password-form/change-password-form.component.ts
@@ -4,6 +4,7 @@ import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 import { AppMatchFieldsValidator } from '@app-buyer/shared/validators/match-fields/match-fields.validator';
 import { AppFormErrorService } from '@app-buyer/shared/services/form-error/form-error.service';
 import { MeUser } from '@ordercloud/angular-sdk';
+import { ValidateStrongPassword } from '@app-buyer/shared/validators/strong-password/strong-password.validator';
 
 @Component({
   selector: 'shared-change-password-form',
@@ -37,9 +38,7 @@ export class ChangePasswordFormComponent implements OnInit {
           '',
           [
             Validators.required,
-            Validators.minLength(8),
-            // matches when there's at least one number and one letter
-            Validators.pattern('^(?=.*[0-9])(?=.*[a-zA-Z])([a-zA-Z0-9]+)$'),
+            ValidateStrongPassword, // password must include one number, one letter and have min length of 8
           ],
         ],
         confirmNewPassword: [''],
@@ -64,8 +63,6 @@ export class ChangePasswordFormComponent implements OnInit {
     this.formErrorService.hasRequiredError(controlName, this.form);
   protected hasPasswordMismatchError = (): boolean =>
     this.formErrorService.hasPasswordMismatchError(this.form);
-  protected hasPatternError = (controlName: string): boolean =>
-    this.formErrorService.hasPatternError(controlName, this.form);
-  protected hasMinLengthError = (controlName: string): boolean =>
-    this.formErrorService.hasMinLengthError(controlName, this.form);
+  protected hasStrongPasswordError = (controlName: string): boolean =>
+    this.formErrorService.hasStrongPasswordError(controlName, this.form);
 }

--- a/src/UI/Buyer/src/app/shared/containers/register/register.component.spec.ts
+++ b/src/UI/Buyer/src/app/shared/containers/register/register.component.spec.ts
@@ -52,7 +52,9 @@ describe('RegisterComponent', () => {
     Get: jasmine.createSpy('Get').and.returnValue(of(me)),
     Patch: jasmine.createSpy('Patch').and.returnValue(of(me)),
     Register: jasmine.createSpy('Register').and.returnValue(of(null)),
-    ResetPasswordByToken: jasmine.createSpy('ResetPasswordByToken').and.returnValue(of(null))
+    ResetPasswordByToken: jasmine
+      .createSpy('ResetPasswordByToken')
+      .and.returnValue(of(null)),
   };
   const activatedRoute = {
     data: new BehaviorSubject({ shouldAllowUpdate: true }),
@@ -66,8 +68,7 @@ describe('RegisterComponent', () => {
     hasRequiredError: jasmine.createSpy('hasRequiredError'),
     hasValidEmailError: jasmine.createSpy('hasValidEmailError'),
     hasPasswordMismatchError: jasmine.createSpy('hasPasswordMismatchError'),
-    hasPatternError: jasmine.createSpy('hasPatternError'),
-    hasMinLengthError: jasmine.createSpy('hasMinLengthError'),
+    hasStrongPasswordError: jasmine.createSpy('hasStrongPasswordError'),
     displayFormErrors: jasmine.createSpy('displayFormErrors'),
   };
   const modalService = {
@@ -75,10 +76,10 @@ describe('RegisterComponent', () => {
     close: jasmine.createSpy('close'),
     add: jasmine.createSpy('add'),
     remove: jasmine.createSpy('remove'),
-    onCloseSubject: new Subject<string>()
+    onCloseSubject: new Subject<string>(),
   };
   let ocAuthService = {
-    Login: () => { },
+    Login: () => {},
   };
 
   beforeEach(async(() => {
@@ -133,7 +134,7 @@ describe('RegisterComponent', () => {
     it('should identify whether component should allow update or just creation', () => {
       component.ngOnInit();
       expect(component['identifyShouldAllowUpdate']).toHaveBeenCalled();
-    })
+    });
     it('should call getMeData if shouldAllowUpdate is true', () => {
       activatedRoute.data.next({ shouldAllowUpdate: true });
       component.ngOnInit();
@@ -152,11 +153,11 @@ describe('RegisterComponent', () => {
       mockModalId = 'mock id';
       component.changePasswordModalId = mockModalId;
       component.openChangePasswordModal();
-    })
+    });
     it('should open modal', () => {
-      expect(modalService.open).toHaveBeenCalledWith(mockModalId)
-    })
-  })
+      expect(modalService.open).toHaveBeenCalledWith(mockModalId);
+    });
+  });
 
   describe('setForm', () => {
     it('should set form with password and confirmPassword if shouldAllowUpdate is false', () => {
@@ -186,31 +187,45 @@ describe('RegisterComponent', () => {
   describe('onChangePassword', () => {
     beforeEach(() => {
       component.me = { Username: 'crhistian' };
-    })
+    });
     afterEach(() => {
       ocMeService.ResetPasswordByToken.calls.reset();
-    })
+    });
     it('should verify user knows current password for security purposes', () => {
       spyOn(ocAuthService, 'Login').and.returnValue(of(null));
-      component.onChangePassword({ currentPassword: 'password123', newPassword: 'new-pw' });
+      component.onChangePassword({
+        currentPassword: 'password123',
+        newPassword: 'new-pw',
+      });
       expect(ocAuthService.Login).toHaveBeenCalledWith(
         component.me.Username,
         'password123',
         component['appConfig'].clientID,
-        component['appConfig'].scope)
-    })
+        component['appConfig'].scope
+      );
+    });
     it('should reset password if verification of current password succeeds', () => {
-      spyOn(ocAuthService, 'Login').and.returnValue(of(null))
-      component.onChangePassword({ currentPassword: 'incorrect-pw', newPassword: 'new-pw' });
-      expect(ocMeService.ResetPasswordByToken).toHaveBeenCalledWith({ NewPassword: 'new-pw' });
-    })
+      spyOn(ocAuthService, 'Login').and.returnValue(of(null));
+      component.onChangePassword({
+        currentPassword: 'incorrect-pw',
+        newPassword: 'new-pw',
+      });
+      expect(ocMeService.ResetPasswordByToken).toHaveBeenCalledWith({
+        NewPassword: 'new-pw',
+      });
+    });
     it('should close modal on successful change', () => {
-      component.changePasswordModalId = 'mockModalId'
-      spyOn(ocAuthService, 'Login').and.returnValue(of(null))
-      component.onChangePassword({ currentPassword: 'incorrect-pw', newPassword: 'new-pw' });
-      expect(component['modalService'].close).toHaveBeenCalledWith('mockModalId');
-    })
-  })
+      component.changePasswordModalId = 'mockModalId';
+      spyOn(ocAuthService, 'Login').and.returnValue(of(null));
+      component.onChangePassword({
+        currentPassword: 'incorrect-pw',
+        newPassword: 'new-pw',
+      });
+      expect(component['modalService'].close).toHaveBeenCalledWith(
+        'mockModalId'
+      );
+    });
+  });
 
   describe('onSubmit', () => {
     beforeEach(() => {

--- a/src/UI/Buyer/src/app/shared/index.ts
+++ b/src/UI/Buyer/src/app/shared/index.ts
@@ -32,6 +32,7 @@ export * from '@app-buyer/shared/services/reorder/reorder.service';
 // validators
 export * from '@app-buyer/shared/validators/match-fields/match-fields.validator';
 export * from '@app-buyer/shared/validators/product-quantity/product.quantity.validator';
+export * from '@app-buyer/shared/validators/strong-password/strong-password.validator';
 
 // modules
 export * from '@app-buyer/shared/shared-routing.module';

--- a/src/UI/Buyer/src/app/shared/services/form-error/form-error.service.ts
+++ b/src/UI/Buyer/src/app/shared/services/form-error/form-error.service.ts
@@ -31,6 +31,10 @@ export class AppFormErrorService {
     );
   }
 
+  hasStrongPasswordError(controlName: string, form: FormGroup) {
+    return form.get(controlName).hasError('strongPassword');
+  }
+
   hasMinLengthError(controlName: string, form: FormGroup) {
     return (
       form.get(controlName).hasError('minlength') && form.get(controlName).dirty

--- a/src/UI/Buyer/src/app/shared/validators/strong-password/strong-password.validator.spec.ts
+++ b/src/UI/Buyer/src/app/shared/validators/strong-password/strong-password.validator.spec.ts
@@ -1,0 +1,34 @@
+import { ValidateStrongPassword } from '@app-buyer/shared/validators/strong-password/strong-password.validator';
+import { FormControl } from '@angular/forms';
+
+describe('ValidateStrongPassword Validator', () => {
+  it('should not error on an empty string', () => {
+    expect(ValidateStrongPassword(new FormControl(''))).toBeNull();
+  });
+  it('should not error on null', () => {
+    expect(ValidateStrongPassword(new FormControl(null))).toBeNull();
+  });
+  it('should return a validation error if length is less than 8 characters', () => {
+    expect(ValidateStrongPassword(new FormControl('abc123'))).toEqual({
+      strongPassword: true,
+    });
+  });
+  it('should return validation error if there is no numbers', () => {
+    expect(ValidateStrongPassword(new FormControl('abcdefghijkl'))).toEqual({
+      strongPassword: true,
+    });
+  });
+  it('should return validation error if there is no letters', () => {
+    expect(ValidateStrongPassword(new FormControl('12345678910'))).toEqual({
+      strongPassword: true,
+    });
+  });
+  it('should be valid if greater than 8 characters, with at least one number and one letter', () => {
+    expect(ValidateStrongPassword(new FormControl('fails345'))).toBeNull();
+  });
+  it('should handle password with special characters', () => {
+    expect(
+      ValidateStrongPassword(new FormControl('awe3somesauce!*(#F'))
+    ).toBeNull();
+  });
+});

--- a/src/UI/Buyer/src/app/shared/validators/strong-password/strong-password.validator.ts
+++ b/src/UI/Buyer/src/app/shared/validators/strong-password/strong-password.validator.ts
@@ -1,0 +1,20 @@
+import { AbstractControl, ValidationErrors } from '@angular/forms';
+
+/**
+ * validates that a given password adheres to ordercloud's password requirements
+ * of at least one letter, at least one letter, and a minimum length of 8
+ */
+export function ValidateStrongPassword(
+  control: AbstractControl
+): ValidationErrors | null {
+  const hasNumber = /[0-9]/.test(control.value);
+  const hasLetter = /[a-zA-Z]/.test(control.value);
+  const hasMinLength = control.value && control.value.length >= 8;
+  if (!control.value) {
+    return null;
+  }
+  if (hasNumber && hasLetter && hasMinLength) {
+    return null;
+  }
+  return { strongPassword: true };
+}


### PR DESCRIPTION
# Description

This PR enforces the ordercloud password standards on forgot password flow as well as change password in profile. The minimum requirements are at least one letter, one number and min length 8 

I also updated *how* the password gets checked. I was using one clunky regex but noticed it wasn't even checking it correctly. I'm now using a custom validator which under the hood still uses regex but does it in parts. This makes it a lot easier for other devs to see what's going on and add to the existing password requirements if they want to make passwords more strict.

For Reference #143

## Type of change
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ x] Refactor (change/optimize code without changing external behavior)

# Checklist:

- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
