### PR TITLE
add cache interceptor to fix IE aggressive cache bug

### DIFF
--- a/src/UI/Buyer/src/app/app.module.ts
+++ b/src/UI/Buyer/src/app/app.module.ts
@@ -32,6 +32,7 @@ import { FaqComponent } from './static-pages/faq/faq.component';
 import {
   AutoAppendTokenInterceptor,
   RefreshTokenInterceptor,
+  CacheInterceptor,
 } from '@app-buyer/auth';
 
 // date picker config
@@ -40,7 +41,12 @@ import { NgbDateNativeAdapter } from '@app-buyer/config/date-picker.config';
 import { TermsAndConditionsComponent } from './static-pages/terms-and-conditions/terms-and-conditions.component';
 
 @NgModule({
-  declarations: [AppComponent, SupportComponent, FaqComponent, TermsAndConditionsComponent],
+  declarations: [
+    AppComponent,
+    SupportComponent,
+    FaqComponent,
+    TermsAndConditionsComponent,
+  ],
   imports: [
     /**
      * app modules
@@ -75,8 +81,13 @@ import { TermsAndConditionsComponent } from './static-pages/terms-and-conditions
       useClass: RefreshTokenInterceptor,
       multi: true,
     },
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: CacheInterceptor,
+      multi: true,
+    },
     { provide: NgbDateAdapter, useClass: NgbDateNativeAdapter },
   ],
   bootstrap: [AppComponent],
 })
-export class AppModule { }
+export class AppModule {}

--- a/src/UI/Buyer/src/app/auth/index.ts
+++ b/src/UI/Buyer/src/app/auth/index.ts
@@ -6,6 +6,7 @@ export * from '@app-buyer/auth/containers/reset-password/reset-password.componen
 // interceptors
 export * from '@app-buyer/auth/interceptors/refresh-token/refresh-token.interceptor';
 export * from '@app-buyer/auth/interceptors/auto-append-token/auto-append-token.interceptor';
+export * from '@app-buyer/auth/interceptors/cache/cache-interceptor';
 
 // services
 export * from '@app-buyer/auth/services/app-auth.service';

--- a/src/UI/Buyer/src/app/auth/interceptors/auto-append-token/auto-append-token.interceptor.spec.ts
+++ b/src/UI/Buyer/src/app/auth/interceptors/auto-append-token/auto-append-token.interceptor.spec.ts
@@ -6,11 +6,8 @@ import {
 } from '@angular/common/http/testing';
 
 import { AutoAppendTokenInterceptor } from '@app-buyer/auth/interceptors/auto-append-token/auto-append-token.interceptor';
-import {
-  applicationConfiguration,
-  AppConfig,
-} from '@app-buyer/config/app.config';
-import { OcTokenService, Configuration } from '@ordercloud/angular-sdk';
+import { applicationConfiguration } from '@app-buyer/config/app.config';
+import { OcTokenService } from '@ordercloud/angular-sdk';
 import { CookieModule } from 'ngx-cookie';
 
 describe('AutoAppendTokenInterceptor', () => {

--- a/src/UI/Buyer/src/app/auth/interceptors/cache/cache-interceptor.spec.ts
+++ b/src/UI/Buyer/src/app/auth/interceptors/cache/cache-interceptor.spec.ts
@@ -1,0 +1,93 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClient, HTTP_INTERCEPTORS } from '@angular/common/http';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+import { CacheInterceptor } from '@app-buyer/auth/interceptors/cache/cache-interceptor';
+
+describe('CacheInterceptor', () => {
+  let interceptor;
+  let httpClient: HttpClient;
+  let httpMock: HttpTestingController;
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        CacheInterceptor,
+        {
+          provide: HTTP_INTERCEPTORS,
+          useClass: CacheInterceptor,
+          multi: true,
+        },
+      ],
+    });
+    interceptor = TestBed.get(CacheInterceptor);
+    httpClient = TestBed.get(HttpClient);
+    httpMock = TestBed.get(HttpTestingController);
+  });
+
+  it('should be created', () => {
+    expect(interceptor).toBeTruthy();
+  });
+
+  describe('non-get requests', () => {
+    const nonGetHttpVerbs = ['post', 'put', 'patch', 'delete'];
+    beforeEach(() => {
+      // mocking user agent to be IE11
+      window.navigator['__defineGetter__']('userAgent', () => {
+        return 'Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko';
+      });
+    });
+    nonGetHttpVerbs.forEach((verb) => {
+      it('should not be cached', () => {
+        // create a request for each non-get verb and assert that no cache headers are added
+        httpClient[verb]('some-mock-url').subscribe((response) => {
+          expect(response).toBeTruthy();
+        });
+        const req = httpMock.expectOne('some-mock-url');
+        expect(req.request.headers.get('Cache-Control')).toBeNull();
+        expect(req.request.headers.get('Pragma')).toBeNull();
+        expect(req.request.headers.get('Expires')).toBeNull();
+        req.flush({ hello: 'world' });
+        httpMock.verify();
+      });
+    });
+  });
+
+  it('should not cache non-ie requests', () => {
+    // mocking user agent to be chrome (something other than IE11)
+    window.navigator['__defineGetter__']('userAgent', () => {
+      return 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36';
+    });
+    // create a get request and assert
+    httpClient.get('some-mock-url').subscribe((response) => {
+      expect(response).toBeTruthy();
+    });
+    const req = httpMock.expectOne('some-mock-url');
+    expect(req.request.headers.get('Cache-Control')).toBeNull();
+    expect(req.request.headers.get('Pragma')).toBeNull();
+    expect(req.request.headers.get('Expires')).toBeNull();
+    req.flush({ hello: 'world' });
+    httpMock.verify();
+  });
+
+  it('IE11 get requests should be cached', () => {
+    // mocking user agent to be IE11
+    window.navigator['__defineGetter__']('userAgent', () => {
+      return 'Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko';
+    });
+    // create a request for each non-get verb and assert that no cache headers are added
+    httpClient.get('some-mock-url').subscribe((response) => {
+      expect(response).toBeTruthy();
+    });
+    const req = httpMock.expectOne('some-mock-url');
+    expect(req.request.headers.get('Cache-Control')).toBe('no-cache');
+    expect(req.request.headers.get('Pragma')).toBe('no-cache');
+    expect(req.request.headers.get('Expires')).toBe(
+      'Sat, 01 Jan 2000 00:00:00 GMT'
+    );
+    req.flush({ hello: 'world' });
+    httpMock.verify();
+  });
+});

--- a/src/UI/Buyer/src/app/auth/interceptors/cache/cache-interceptor.ts
+++ b/src/UI/Buyer/src/app/auth/interceptors/cache/cache-interceptor.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@angular/core';
+import {
+  HttpRequest,
+  HttpHandler,
+  HttpEvent,
+  HttpInterceptor,
+} from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+/**
+ * append headers to disable IE11's aggressive caching of GET requests
+ * see here for more info on bug: https://medium.com/@tltjr/disabling-internet-explorer-caching-in-your-angular-5-application-3e148f4437ad
+ *
+ * we've augmented the suggested solution to check  first if the browser
+ * is IE11 and to ensure the request is a 'GET' as those are the affected calls
+ * we'd like to keep caching mechanisms for other browsers and request types because
+ * some things should rightfully be cached
+ */
+@Injectable()
+export class CacheInterceptor implements HttpInterceptor {
+  constructor() {}
+  intercept(
+    request: HttpRequest<any>,
+    next: HttpHandler
+  ): Observable<HttpEvent<any>> {
+    const hasIE11 = window.navigator.userAgent.includes('Trident/');
+    if (hasIE11 && request.method === 'GET') {
+      request = request.clone({
+        setHeaders: {
+          'Cache-Control': 'no-cache',
+          Pragma: 'no-cache',
+          Expires: 'Sat, 01 Jan 2000 00:00:00 GMT',
+        },
+      });
+    }
+    return next.handle(request);
+  }
+}

--- a/src/UI/Seller/src/app/app.module.ts
+++ b/src/UI/Seller/src/app/app.module.ts
@@ -19,6 +19,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { SharedModule } from '@app-seller/shared';
 import { NgProgressModule } from '@ngx-progressbar/core';
 import { NgProgressHttpModule } from '@ngx-progressbar/http';
+import { CacheInterceptor } from '@app-seller/auth/interceptors/cache/cache-interceptor';
 
 @NgModule({
   declarations: [AppComponent],
@@ -51,6 +52,11 @@ import { NgProgressHttpModule } from '@ngx-progressbar/http';
     {
       provide: HTTP_INTERCEPTORS,
       useClass: RefreshTokenInterceptor,
+      multi: true,
+    },
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: CacheInterceptor,
       multi: true,
     },
   ],

--- a/src/UI/Seller/src/app/auth/interceptors/cache/cache-interceptor.spec.ts
+++ b/src/UI/Seller/src/app/auth/interceptors/cache/cache-interceptor.spec.ts
@@ -1,0 +1,93 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClient, HTTP_INTERCEPTORS } from '@angular/common/http';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+import { CacheInterceptor } from '@app-seller/auth/interceptors/cache/cache-interceptor';
+
+describe('CacheInterceptor', () => {
+  let interceptor;
+  let httpClient: HttpClient;
+  let httpMock: HttpTestingController;
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        CacheInterceptor,
+        {
+          provide: HTTP_INTERCEPTORS,
+          useClass: CacheInterceptor,
+          multi: true,
+        },
+      ],
+    });
+    interceptor = TestBed.get(CacheInterceptor);
+    httpClient = TestBed.get(HttpClient);
+    httpMock = TestBed.get(HttpTestingController);
+  });
+
+  it('should be created', () => {
+    expect(interceptor).toBeTruthy();
+  });
+
+  describe('non-get requests', () => {
+    const nonGetHttpVerbs = ['post', 'put', 'patch', 'delete'];
+    beforeEach(() => {
+      // mocking user agent to be IE11
+      window.navigator['__defineGetter__']('userAgent', () => {
+        return 'Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko';
+      });
+    });
+    nonGetHttpVerbs.forEach((verb) => {
+      it('should not be cached', () => {
+        // create a request for each non-get verb and assert that no cache headers are added
+        httpClient[verb]('some-mock-url').subscribe((response) => {
+          expect(response).toBeTruthy();
+        });
+        const req = httpMock.expectOne('some-mock-url');
+        expect(req.request.headers.get('Cache-Control')).toBeNull();
+        expect(req.request.headers.get('Pragma')).toBeNull();
+        expect(req.request.headers.get('Expires')).toBeNull();
+        req.flush({ hello: 'world' });
+        httpMock.verify();
+      });
+    });
+  });
+
+  it('should not cache non-ie requests', () => {
+    // mocking user agent to be chrome (something other than IE11)
+    window.navigator['__defineGetter__']('userAgent', () => {
+      return 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36';
+    });
+    // create a get request and assert
+    httpClient.get('some-mock-url').subscribe((response) => {
+      expect(response).toBeTruthy();
+    });
+    const req = httpMock.expectOne('some-mock-url');
+    expect(req.request.headers.get('Cache-Control')).toBeNull();
+    expect(req.request.headers.get('Pragma')).toBeNull();
+    expect(req.request.headers.get('Expires')).toBeNull();
+    req.flush({ hello: 'world' });
+    httpMock.verify();
+  });
+
+  it('IE11 get requests should be cached', () => {
+    // mocking user agent to be IE11
+    window.navigator['__defineGetter__']('userAgent', () => {
+      return 'Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko';
+    });
+    // create a request for each non-get verb and assert that no cache headers are added
+    httpClient.get('some-mock-url').subscribe((response) => {
+      expect(response).toBeTruthy();
+    });
+    const req = httpMock.expectOne('some-mock-url');
+    expect(req.request.headers.get('Cache-Control')).toBe('no-cache');
+    expect(req.request.headers.get('Pragma')).toBe('no-cache');
+    expect(req.request.headers.get('Expires')).toBe(
+      'Sat, 01 Jan 2000 00:00:00 GMT'
+    );
+    req.flush({ hello: 'world' });
+    httpMock.verify();
+  });
+});

--- a/src/UI/Seller/src/app/auth/interceptors/cache/cache-interceptor.ts
+++ b/src/UI/Seller/src/app/auth/interceptors/cache/cache-interceptor.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@angular/core';
+import {
+  HttpRequest,
+  HttpHandler,
+  HttpEvent,
+  HttpInterceptor,
+} from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+/**
+ * append headers to disable IE11's aggressive caching of GET requests
+ * see here for more info on bug: https://medium.com/@tltjr/disabling-internet-explorer-caching-in-your-angular-5-application-3e148f4437ad
+ *
+ * we've augmented the suggested solution to check  first if the browser
+ * is IE11 and to ensure the request is a 'GET' as those are the affected calls
+ * we'd like to keep caching mechanisms for other browsers and request types because
+ * some things should rightfully be cached
+ */
+@Injectable()
+export class CacheInterceptor implements HttpInterceptor {
+  constructor() {}
+  intercept(
+    request: HttpRequest<any>,
+    next: HttpHandler
+  ): Observable<HttpEvent<any>> {
+    const hasIE11 = window.navigator.userAgent.includes('Trident/');
+    if (hasIE11 && request.method === 'GET') {
+      request = request.clone({
+        setHeaders: {
+          'Cache-Control': 'no-cache',
+          Pragma: 'no-cache',
+          Expires: 'Sat, 01 Jan 2000 00:00:00 GMT',
+        },
+      });
+    }
+    return next.handle(request);
+  }
+}


### PR DESCRIPTION
# Description

Create an interceptor to append "cache-busting" headers for IE11 GET requests. This is to fix an IE11 bug where GET requests are aggressively cached and the app doesn't update as required. 

See here for more info on bug: https://medium.com/@tltjr/disabling-internet-explorer-caching-in-your-angular-5-application-3e148f4437ad

I've augmented the suggested solution to check  first if the browser is IE11 and to ensure the request is a 'GET' as those are the affected calls. We'd like to keep caching mechanisms for other browsers and request types as-is because some things should rightfully be cached.

For Reference #165 and #155 and probably other seller issues

## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [ ] I have updated the acceptance criteria on the task so that it can be tested
