### PR TITLE
fix: IE bug when changing sortBy #181

### DIFF
--- a/src/UI/Buyer/src/app/products/components/sort-filter/sort-filter.component.html
+++ b/src/UI/Buyer/src/app/products/components/sort-filter/sort-filter.component.html
@@ -5,8 +5,8 @@
             (change)="sortStrategyChanged()">
       <option [ngValue]="null"
               disabled>None</option>
-      <option [ngValue]="option.key"
-              *ngFor="let option of options | mapToIterable">
+      <option *ngFor="let option of options"
+              [ngValue]="option.label">
         {{ option.value }}
       </option>
     </select>

--- a/src/UI/Buyer/src/app/products/components/sort-filter/sort-filter.component.spec.ts
+++ b/src/UI/Buyer/src/app/products/components/sort-filter/sort-filter.component.spec.ts
@@ -28,10 +28,25 @@ describe('SortFilterComponent', () => {
   describe('ngOnInit', () => {
     beforeEach(() => {
       spyOn(component as any, 'setForm');
+      spyOn(component as any, 'getOptions');
       component.ngOnInit();
+    });
+    it('should set options', () => {
+      expect(component['getOptions']).toHaveBeenCalled();
     });
     it('should set the form', () => {
       expect(component['setForm']).toHaveBeenCalled();
+    });
+  });
+
+  describe('setForm', () => {
+    beforeEach(() => {
+      component['setForm']();
+    });
+    it('should initialize the form', () => {
+      expect(component.form.value).toEqual({
+        strategy: null,
+      });
     });
   });
 

--- a/src/UI/Buyer/src/app/products/components/sort-filter/sort-filter.component.ts
+++ b/src/UI/Buyer/src/app/products/components/sort-filter/sort-filter.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 import { FormGroup, FormBuilder } from '@angular/forms';
 import { ProductSortStrategy } from '@app-buyer/products/models/product-sort-strategy.enum';
+import { each as _each } from 'lodash';
 
 @Component({
   selector: 'products-sort-filter',
@@ -9,19 +10,28 @@ import { ProductSortStrategy } from '@app-buyer/products/models/product-sort-str
 })
 export class SortFilterComponent implements OnInit {
   form: FormGroup;
-  options = ProductSortStrategy;
+  options: { label: string; value: string }[];
   @Input() sortStrategy?: string;
   @Output() sortStrategyChange = new EventEmitter<ProductSortStrategy>();
 
   constructor(private formBuilder: FormBuilder) {}
 
   ngOnInit() {
+    this.options = this.getOptions();
     this.setForm();
+  }
+
+  private getOptions(): { label: string; value: string }[] {
+    let options = [];
+    _each(ProductSortStrategy, (strategyVal, strategyName) => {
+      options = [...options, { label: strategyName, value: strategyVal }];
+    });
+    return options;
   }
 
   private setForm() {
     this.form = this.formBuilder.group({
-      strategy: this.options[this.sortStrategy],
+      strategy: this.options.find((x) => x.value === this.sortStrategy),
     });
   }
 


### PR DESCRIPTION
# Description

Doesn't look like IE can handle iterating over objects very well. Converted the options into a collection in the class and then iterated over that

For Reference #181 

## Type of change
- [ x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [ ] I have updated the acceptance criteria on the task so that it can be tested
