### PR TITLE
allow Username to be editable in buyer app

### DIFF
--- a/src/UI/Buyer/src/app/shared/containers/register/register.component.html
+++ b/src/UI/Buyer/src/app/shared/containers/register/register.component.html
@@ -1,63 +1,133 @@
-<div *ngIf="!shouldAllowUpdate" class="text-center mt-3">
-  <p>Already have an account? <button type="button" class="btn btn-link" routerLink="/login">Login</button></p>
+<div *ngIf="!shouldAllowUpdate"
+     class="text-center mt-3">
+  <p>Already have an account? <button type="button"
+            class="btn btn-link"
+            routerLink="/login">Login</button></p>
   <h1 class="display-4">{{appConfig.appname}}</h1>
 </div>
 <div *ngIf="shouldAllowUpdate">
   <h1 class="page-heading border-bottom pb-3">Account Details</h1>
 </div>
 <div class="row">
-  <div class="col-lg-6" [ngClass]="{'mx-auto': !shouldAllowUpdate}" [ngStyle]="{'max-width': !shouldAllowUpdate ? '350px' : ''}">
-    <h3 *ngIf="!shouldAllowUpdate" class="text-center headline-text mb-3">Sign Up</h3>
-    <form (ngSubmit)="onSubmit()" novalidate [formGroup]="form" name="RegisterForm">
+  <div class="col-lg-6"
+       [ngClass]="{'mx-auto': !shouldAllowUpdate}"
+       [ngStyle]="{'max-width': !shouldAllowUpdate ? '350px' : ''}">
+    <h3 *ngIf="!shouldAllowUpdate"
+        class="text-center headline-text mb-3">Sign Up</h3>
+    <form (ngSubmit)="onSubmit()"
+          novalidate
+          [formGroup]="form"
+          name="RegisterForm">
       <div class="form-group">
-        <label [ngClass]="{'sr-only': !shouldAllowUpdate}" for="FirstName">First Name</label>
-        <input type="text" formControlName="FirstName" class="form-control" id="FirstName" placeholder="First Name" autofocus="true"
-          autocomplete="off" />
-        <span *ngIf="hasRequiredError('FirstName')" class="error-message">First Name is required</span>
+        <label [ngClass]="{'sr-only': !shouldAllowUpdate}"
+               for="Username">Username</label>
+        <input type="text"
+               formControlName="Username"
+               class="form-control"
+               id="Username"
+               placeholder="Username"
+               autofocus="true"
+               autocomplete="off" />
+        <span *ngIf="hasRequiredError('Username')"
+              class="error-message">Username is required</span>
       </div>
       <div class="form-group">
-        <label [ngClass]="{'sr-only': !shouldAllowUpdate}" for="LastName">Last Name</label>
-        <input type="text" formControlName="LastName" class="form-control" id="LastName" placeholder="Last Name" autocomplete="off"
-        />
-        <span *ngIf="hasRequiredError('LastName')" class="error-message">Last Name is required</span>
+        <label [ngClass]="{'sr-only': !shouldAllowUpdate}"
+               for="FirstName">First Name</label>
+        <input type="text"
+               formControlName="FirstName"
+               class="form-control"
+               id="FirstName"
+               placeholder="First Name"
+               autocomplete="off" />
+        <span *ngIf="hasRequiredError('FirstName')"
+              class="error-message">First Name is required</span>
       </div>
       <div class="form-group">
-        <label [ngClass]="{'sr-only': !shouldAllowUpdate}" for="Email">Email</label>
-        <input type="email" formControlName="Email" class="form-control" id="Email" placeholder="Email" autocomplete="off" />
-        <span *ngIf="hasValidEmailError()" class="error-message">Please enter valid Email</span>
+        <label [ngClass]="{'sr-only': !shouldAllowUpdate}"
+               for="LastName">Last Name</label>
+        <input type="text"
+               formControlName="LastName"
+               class="form-control"
+               id="LastName"
+               placeholder="Last Name"
+               autocomplete="off" />
+        <span *ngIf="hasRequiredError('LastName')"
+              class="error-message">Last Name is required</span>
       </div>
       <div class="form-group">
-        <label [ngClass]="{'sr-only': !shouldAllowUpdate}" for="Phone">Phone Number</label>
-        <input type="text" formControlName="Phone" class="form-control" appPhoneInput id="Phone" placeholder="Phone Number" autocomplete="off"
-        />
+        <label [ngClass]="{'sr-only': !shouldAllowUpdate}"
+               for="Email">Email</label>
+        <input type="email"
+               formControlName="Email"
+               class="form-control"
+               id="Email"
+               placeholder="Email"
+               autocomplete="off" />
+        <span *ngIf="hasValidEmailError()"
+              class="error-message">Please enter valid Email</span>
       </div>
-      <div *ngIf="!shouldAllowUpdate" class="form-group">
-        <label [ngClass]="{'sr-only': !shouldAllowUpdate}" for="Password">Password</label>
-        <input type="password" formControlName="Password" class="form-control" id="Password" placeholder="Password" autocomplete="off"
-        />
-        <span *ngIf="hasRequiredError('Password')" class="error-message">Password is required</span>
+      <div class="form-group">
+        <label [ngClass]="{'sr-only': !shouldAllowUpdate}"
+               for="Phone">Phone Number</label>
+        <input type="text"
+               formControlName="Phone"
+               class="form-control"
+               appPhoneInput
+               id="Phone"
+               placeholder="Phone Number"
+               autocomplete="off" />
       </div>
-      <div *ngIf="!shouldAllowUpdate" class="form-group">
-        <label class="sr-only" for="ConfirmPassword">Confirm Password</label>
-        <input type="password" formControlName="ConfirmPassword" class="form-control" id="ConfirmPassword" placeholder="Confirm Password"
-          autocomplete="off" />
-        <span *ngIf="hasRequiredError('ConfirmPassword')" class="error-message">Confirm is required</span>
-        <span *ngIf="passwordMismatchError()" class="error-message">Passwords must match</span>
+      <div *ngIf="!shouldAllowUpdate"
+           class="form-group">
+        <label [ngClass]="{'sr-only': !shouldAllowUpdate}"
+               for="Password">Password</label>
+        <input type="password"
+               formControlName="Password"
+               class="form-control"
+               id="Password"
+               placeholder="Password"
+               autocomplete="off" />
+        <span *ngIf="hasRequiredError('Password')"
+              class="error-message">Password is required</span>
       </div>
-      <button type="button" *ngIf="shouldAllowUpdate" class="btn btn-outline-primary btn-block" (click)="openChangePasswordModal()">Change
+      <div *ngIf="!shouldAllowUpdate"
+           class="form-group">
+        <label class="sr-only"
+               for="ConfirmPassword">Confirm Password</label>
+        <input type="password"
+               formControlName="ConfirmPassword"
+               class="form-control"
+               id="ConfirmPassword"
+               placeholder="Confirm Password"
+               autocomplete="off" />
+        <span *ngIf="hasRequiredError('ConfirmPassword')"
+              class="error-message">Confirm is required</span>
+        <span *ngIf="passwordMismatchError()"
+              class="error-message">Passwords must match</span>
+      </div>
+      <button type="button"
+              *ngIf="shouldAllowUpdate"
+              class="btn btn-outline-primary btn-block"
+              (click)="openChangePasswordModal()">Change
         Password
       </button>
-      <button type="submit" class="btn btn-primary btn-lg btn-block mt-4">{{ shouldAllowUpdate ? 'Save Changes' : 'Register'
+      <button type="submit"
+              class="btn btn-primary btn-lg btn-block mt-4">{{ shouldAllowUpdate ? 'Save Changes' : 'Register'
         }}
       </button>
     </form>
-    <button *ngIf="!shouldAllowUpdate" type="button" class="btn btn-link btn-block" routerLink="/forgot-password">Forgot
+    <button *ngIf="!shouldAllowUpdate"
+            type="button"
+            class="btn btn-link btn-block"
+            routerLink="/forgot-password">Forgot
       Password
     </button>
   </div>
 </div>
 
 <!--  Change Password Modal Content -->
-<shared-modal [id]="changePasswordModalId" modalTitle="Change Password">
+<shared-modal [id]="changePasswordModalId"
+              modalTitle="Change Password">
   <shared-change-password-form (changePassword)="onChangePassword($event)"></shared-change-password-form>
 </shared-modal>

--- a/src/UI/Buyer/src/app/shared/containers/register/register.component.spec.ts
+++ b/src/UI/Buyer/src/app/shared/containers/register/register.component.spec.ts
@@ -19,7 +19,7 @@ import {
   AppStateService,
   AppFormErrorService,
 } from '@app-buyer/shared';
-import { of, Subject, BehaviorSubject, throwError } from 'rxjs';
+import { of, Subject, BehaviorSubject } from 'rxjs';
 import { ChangePasswordFormComponent } from '@app-buyer/shared/components/change-password-form/change-password-form.component';
 import { ModalComponent } from '@app-buyer/shared/components/modal/modal.component';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
@@ -31,6 +31,7 @@ describe('RegisterComponent', () => {
 
   const appStateService = { userSubject: new Subject<any>() };
   const me = {
+    Username: 'crhistianr',
     FirstName: 'Crhistian',
     LastName: 'Ramirez',
     Email: 'crhistian@gmail.com',
@@ -164,6 +165,7 @@ describe('RegisterComponent', () => {
       component.shouldAllowUpdate = false;
       component['setForm']();
       expect(component.form.value).toEqual({
+        Username: '',
         FirstName: '',
         LastName: '',
         Email: '',
@@ -176,6 +178,7 @@ describe('RegisterComponent', () => {
       component.shouldAllowUpdate = true;
       component['setForm']();
       expect(component.form.value).toEqual({
+        Username: '',
         FirstName: '',
         LastName: '',
         Email: '',
@@ -283,6 +286,7 @@ describe('RegisterComponent', () => {
     });
     it('should set form with me data', () => {
       expect(component.form.setValue).toHaveBeenCalledWith({
+        Username: me.Username,
         FirstName: me.FirstName,
         LastName: me.LastName,
         Phone: me.Phone,

--- a/src/UI/Buyer/src/app/shared/containers/register/register.component.ts
+++ b/src/UI/Buyer/src/app/shared/containers/register/register.component.ts
@@ -77,6 +77,7 @@ export class RegisterComponent implements OnInit, OnDestroy {
 
   private setForm() {
     const formObj = {
+      Username: ['', Validators.required],
       FirstName: ['', Validators.required],
       LastName: ['', Validators.required],
       Email: ['', [Validators.required, Validators.email]],
@@ -105,16 +106,15 @@ export class RegisterComponent implements OnInit, OnDestroy {
       )
       .pipe(
         flatMap(() => {
-          return this.ocMeService
-            .ResetPasswordByToken({
-              NewPassword: newPassword,
-            })
+          return this.ocMeService.ResetPasswordByToken({
+            NewPassword: newPassword,
+          });
         })
       )
       .subscribe(() => {
         this.toastrService.success('Account Info Updated', 'Success');
         this.modalService.close(this.changePasswordModalId);
-      })
+      });
   }
 
   onSubmit() {
@@ -123,7 +123,6 @@ export class RegisterComponent implements OnInit, OnDestroy {
     }
 
     const me = <MeUser>this.form.value;
-    me.Username = me.Email;
     me.Active = true;
 
     if (this.shouldAllowUpdate) {
@@ -153,6 +152,7 @@ export class RegisterComponent implements OnInit, OnDestroy {
     this.ocMeService.Get().subscribe((me) => {
       this.me = me;
       this.form.setValue({
+        Username: me.Username,
         FirstName: me.FirstName,
         LastName: me.LastName,
         Phone: me.Phone,


### PR DESCRIPTION
# Description

We had previously been tying Username to Email because we were building this off of a client-specific solution at first. In addition to those fields no longer being coupled I'm exposing the editing of Username on the buyer app. That is a very natural thing to want to change as a buyer

For Reference #186 

## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)

# Checklist:

- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [ ] I have updated the acceptance criteria on the task so that it can be tested
