### PR TITLE
Make phone number optional and fix bug with refresh token interceptor

### DIFF
--- a/src/UI/Buyer/src/app/auth/interceptors/refresh-token/refresh-token.interceptor.ts
+++ b/src/UI/Buyer/src/app/auth/interceptors/refresh-token/refresh-token.interceptor.ts
@@ -29,7 +29,7 @@ export class RefreshTokenInterceptor implements HttpInterceptor {
         } else {
           // if a refresh attempt failed recently then ignore (3 seconds)`
           if (this.appAuthService.failedRefreshAttempt) {
-            return;
+            return throwError(error);
           }
 
           // ensure there is no outstanding request already fetching token

--- a/src/UI/Buyer/src/app/auth/services/app-auth.service.ts
+++ b/src/UI/Buyer/src/app/auth/services/app-auth.service.ts
@@ -98,7 +98,7 @@ export class AppAuthService {
       return this.authAnonymous();
     }
 
-    throwError(TokenRefreshAttemptNotPossible);
+    return throwError(TokenRefreshAttemptNotPossible);
   }
 
   logout(): Observable<any> {

--- a/src/UI/Buyer/src/app/shared/components/address-form/address-form.component.html
+++ b/src/UI/Buyer/src/app/shared/components/address-form/address-form.component.html
@@ -80,9 +80,11 @@
       <select formControlName="State"
               class="form-control"
               id="State">
-          <option [ngValue]="null" disabled>State</option>
-          <option *ngFor="let State of stateOptions" [value]="State">{{ State }}</option>
-        </select>
+        <option [ngValue]="null"
+                disabled>State</option>
+        <option *ngFor="let State of stateOptions"
+                [value]="State">{{ State }}</option>
+      </select>
       <span *ngIf="hasRequiredError('State')"
             class="error-message">State is required</span>
     </div>
@@ -106,9 +108,11 @@
       <select formControlName="Country"
               class="form-control"
               id="Country">
-         <option [ngValue]="null" disabled>Country</option>
-         <option *ngFor="let country of countryOptions" [value]="country.abbreviation">{{ country.label }}</option>
-       </select>
+        <option [ngValue]="null"
+                disabled>Country</option>
+        <option *ngFor="let country of countryOptions"
+                [value]="country.abbreviation">{{ country.label }}</option>
+      </select>
       <span *ngIf="hasRequiredError('Country')"
             class="error-message">Country is required</span>
     </div>
@@ -122,8 +126,6 @@
              appPhoneInput
              placeholder="Phone Number"
              autocomplete="off" />
-      <span *ngIf="hasRequiredError('Phone')"
-            class="error-message">Phone is required</span>
     </div>
   </div>
   <button type="submit"

--- a/src/UI/Buyer/src/app/shared/components/address-form/address-form.component.ts
+++ b/src/UI/Buyer/src/app/shared/components/address-form/address-form.component.ts
@@ -47,7 +47,7 @@ export class AddressFormComponent implements OnInit {
       City: [this._existingAddress.City || '', Validators.required],
       State: [this._existingAddress.State || null, Validators.required],
       Zip: [this._existingAddress.Zip || '', Validators.required],
-      Phone: [this._existingAddress.Phone || '', Validators.required],
+      Phone: [this._existingAddress.Phone || ''],
       Country: [this._existingAddress.Country || null, Validators.required],
       ID: this._existingAddress.ID || '',
     });


### PR DESCRIPTION
# Description

- phone number is optional to match what is in seller, it being required was a holdover from another app
- refresh token interceptor wasn't returning an observable at some points which caused an ugly error message

For Reference #184 

## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [ ] I have updated the acceptance criteria on the task so that it can be tested
