### PR TITLE
[IE BUG] Sticky Footer

### DIFF
--- a/src/UI/Buyer/src/app/app.component.scss
+++ b/src/UI/Buyer/src/app/app.component.scss
@@ -1,5 +1,6 @@
 :host() {
-  min-height: 100vh;
   display: flex;
   flex-flow: column nowrap;
+  flex: 1 1 auto;
+  min-height: calc(100vh - 120px);
 }

--- a/src/UI/Buyer/src/app/layout/footer/footer.component.html
+++ b/src/UI/Buyer/src/app/layout/footer/footer.component.html
@@ -21,7 +21,7 @@
       <small>FAQ</small>
     </a>
   </div>
-  <div class="p-0 mt-0 bg-light text-center text-muted col-sm-12">
+  <div class="p-0 mt-0 text-center text-muted col-sm-12">
     <small>Created by Four51, Inc.</small>
   </div>
 </div>

--- a/src/UI/Buyer/src/app/layout/main/main.component.scss
+++ b/src/UI/Buyer/src/app/layout/main/main.component.scss
@@ -1,4 +1,4 @@
 :host() {
   flex-grow: 1;
-  height: 100%;
+  min-height: 100%;
 }

--- a/src/UI/Buyer/src/styles/_shame.scss
+++ b/src/UI/Buyer/src/styles/_shame.scss
@@ -1,5 +1,10 @@
+html {
+  height: 100vh;
+}
+
 body {
   padding-top: 120px;
+  min-height: 100vh;
 }
 
 .flex-1 {
@@ -24,6 +29,7 @@ body {
 
 .border-hover {
   transition: border-color 0.25s ease;
+
   &:hover {
     border: 1px solid $secondary;
   }
@@ -46,6 +52,7 @@ body {
 shared-address-display {
   display: flex;
   flex: 1 1 auto;
+
   .card {
     @extend shared-address-display;
   }


### PR DESCRIPTION
Need min-height on flex items.

# Description

Fixed navbars require top padding to be applied to the `<body>`. It's this top padding is complicating things for our sticky footer when the viewport height is less than 100%.

Normally, the flexbox children should expand to take up the entire available space; however, because we declare `padding-top:120px`, that available space is being bumped down below the fold. I am starting by declaring the heights on html + body. Then I'm using `calc(100vh - 120px)` on the app root and also setting its flex children to `1 1 auto`. Next we need to declare a `min-height: 100%` on our main layout.

This isn't iron-clad, as you may notice a small amount of space between the bottom of the viewport and the footer on IE. I'm not sure what's causing this yet.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the acceptance criteria on the task so that it can be tested
