### PR TITLE
Seller app: add phone number input to user form field

### DIFF
--- a/src/UI/Seller/package-lock.json
+++ b/src/UI/Seller/package-lock.json
@@ -4179,14 +4179,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4206,8 +4204,7 @@
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",

--- a/src/UI/Seller/src/app/shared/components/user-form/user-form.component.html
+++ b/src/UI/Seller/src/app/shared/components/user-form/user-form.component.html
@@ -63,6 +63,19 @@
             class="error-message">Email is Required</span>
     </div>
   </div>
+  <div class="form-group row">
+    <label for="phonenumber"
+           class="col-sm-3 control-label font-weight-bold mt-1">Phone Number</label>
+    <div class="col-sm-9">
+      <input type="text"
+             formControlName="Phone"
+             class="form-control"
+             appPhoneInput
+             placeholder="(Optional)"
+             id="phonenumber"
+             autocomplete="off" />
+    </div>
+  </div>
   <div class="form-group">
     <div class="col-sm-9 offset-sm-3">
       <input type="checkbox"

--- a/src/UI/Seller/src/app/shared/components/user-form/user-form.component.spec.ts
+++ b/src/UI/Seller/src/app/shared/components/user-form/user-form.component.spec.ts
@@ -14,6 +14,7 @@ describe('UserFormComponent', () => {
     FirstName: 'First',
     LastName: 'Second',
     Email: 'test@email.com',
+    Phone: '(123)456-7890',
     Active: true,
   };
 
@@ -57,6 +58,7 @@ describe('UserFormComponent', () => {
         FirstName: 'First',
         LastName: 'Second',
         Email: 'test@email.com',
+        Phone: '(123)456-7890',
         Active: true,
       });
     });
@@ -82,6 +84,7 @@ describe('UserFormComponent', () => {
           FirstName: 'First',
           LastName: 'Second',
           Email: 'test@email.com',
+          Phone: '(123)456-7890',
           Active: true,
         },
         prevID: '1',

--- a/src/UI/Seller/src/app/shared/components/user-form/user-form.component.ts
+++ b/src/UI/Seller/src/app/shared/components/user-form/user-form.component.ts
@@ -39,6 +39,7 @@ export class UserFormComponent implements OnInit {
       Username: this._existingUser.Username || '',
       FirstName: this._existingUser.FirstName || '',
       LastName: this._existingUser.LastName || '',
+      Phone: this._existingUser.Phone || '',
       Email: this._existingUser.Email || '',
       Active: !!this._existingUser.Active,
     });
@@ -50,6 +51,7 @@ export class UserFormComponent implements OnInit {
       Username: [this._existingUser.Username || '', Validators.required],
       FirstName: [this._existingUser.FirstName || '', Validators.required],
       LastName: [this._existingUser.LastName || '', Validators.required],
+      Phone: [this._existingUser.Phone || '', Validators.required],
       Email: [this._existingUser.Email || '', Validators.required],
       Active: [!!this._existingUser.Active],
     });

--- a/src/UI/Seller/src/app/shared/directives/phone-input/phone-input.directive.ts
+++ b/src/UI/Seller/src/app/shared/directives/phone-input/phone-input.directive.ts
@@ -1,0 +1,40 @@
+import { Directive, ElementRef, HostListener } from '@angular/core';
+import { PhoneFormatPipe } from '@app-seller/shared/pipes/phone-format/phone-format.pipe';
+
+@Directive({ selector: '[appPhoneInput]' })
+// Directive class
+export class PhoneInputDirective {
+  constructor(private el: ElementRef, private phoneFormat: PhoneFormatPipe) {}
+
+  @HostListener('keyup')
+  keyUp() {
+    this.format();
+  }
+
+  // Cap the length of the field at 14 characters - 10 numbers plus 4 characters
+  @HostListener('keydown', ['$event'])
+  keyDown(event: KeyboardEvent) {
+    const key = event.keyCode;
+    if (!this.allowedKeys(key) && this.el.nativeElement.value.length === 14) {
+      event.preventDefault();
+    }
+  }
+
+  format() {
+    this.el.nativeElement.value = this.phoneFormat.transform(
+      this.el.nativeElement.value
+    );
+  }
+
+  allowedKeys(key) {
+    if (!key) {
+      return true;
+    }
+    const isCtrlAltShift = 15 < key && key < 19;
+    const isArrowKeys = 37 <= key && key <= 40;
+    const isMetaKeys = key === 91;
+    const isDelete = key === 46 || key === 8;
+    const isTab = key === 9;
+    return isCtrlAltShift || isArrowKeys || isMetaKeys || isDelete || isTab;
+  }
+}

--- a/src/UI/Seller/src/app/shared/pipes/phone-format/phone-format.pipe.ts
+++ b/src/UI/Seller/src/app/shared/pipes/phone-format/phone-format.pipe.ts
@@ -1,0 +1,40 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'tel',
+})
+export class PhoneFormatPipe implements PipeTransform {
+  transform(tel: string) {
+    if (!tel) {
+      return '';
+    }
+
+    const value = tel
+      .toString()
+      .trim()
+      .replace(/[^0-9]/g, '');
+
+    let city, number;
+
+    switch (value.length) {
+      case 1:
+      case 2:
+      case 3:
+        city = value;
+        break;
+
+      default:
+        city = value.slice(0, 3);
+        number = value.slice(3);
+    }
+    if (number) {
+      if (number.length > 3) {
+        number = `${number.slice(0, 3)}-${number.slice(3, 7)}`;
+      }
+
+      return `(${city}) ${number}`.trim();
+    } else {
+      return `(${city}`;
+    }
+  }
+}

--- a/src/UI/Seller/src/app/shared/shared.module.ts
+++ b/src/UI/Seller/src/app/shared/shared.module.ts
@@ -34,6 +34,13 @@ import { CategoryDetailsComponent } from './containers/category-details/category
 import { ProductTableComponent } from '@app-seller/shared/containers/product-table/product-table.component';
 import { ProductFormComponent } from '@app-seller/shared/components/products-form/product-form.component';
 
+// pipes
+import { PhoneFormatPipe } from '@app-seller/shared/pipes/phone-format/phone-format.pipe';
+
+// directives
+import { PhoneInputDirective } from '@app-seller/shared/directives/phone-input/phone-input.directive';
+
+
 @NgModule({
   imports: [
     SharedRoutingModule,
@@ -60,6 +67,12 @@ import { ProductFormComponent } from '@app-seller/shared/components/products-for
     FontAwesomeModule,
     NgbPaginationModule,
     NgbTabsetModule,
+
+    // pipes
+    PhoneFormatPipe,
+    
+    // directives
+    PhoneInputDirective,
 
     // app components
     SearchComponent,
@@ -92,6 +105,8 @@ import { ProductFormComponent } from '@app-seller/shared/components/products-for
     CategoryDetailsComponent,
     ProductTableComponent,
     ProductFormComponent,
+    PhoneFormatPipe,
+    PhoneInputDirective,
   ],
 
   /**
@@ -113,6 +128,8 @@ export class SharedModule {
     return {
       ngModule: SharedModule,
       providers: [
+        PhoneFormatPipe,
+
         AppErrorHandler,
         { provide: ErrorHandler, useClass: AppErrorHandler },
       ],


### PR DESCRIPTION
## Description

<!--  
- Summary of the change and which issue is fixed.
Added phone number field to the user creation modal on the seller app.

- Relevant motivation and context.
This is an optional field that can be changed by the user themselves on the buyer app. The admin user now has the ability to change this field.

- List any dependencies that are required for this change.
n.a.

-->

For Reference # (issue)

## Type of change

<!-- Please delete options that are not relevant -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the acceptance criteria on the task so that it can be tested
- [ ] I have verified my contribution works and looks well in Firefox, Safari and Internet Explorer
