### PR TITLE
Fixing four small bugs.

### DIFF
--- a/src/UI/Buyer/.vscode/settings.json
+++ b/src/UI/Buyer/.vscode/settings.json
@@ -5,5 +5,8 @@
   "tslint.autoFixOnSave": true,
   "[scss]": {
     "editor.formatOnSave": false
+  },
+  "search.exclude": {
+    "**/dist": true
   }
 }

--- a/src/UI/Buyer/src/app/checkout/containers/checkout-address/checkout-address.component.html
+++ b/src/UI/Buyer/src/app/checkout/containers/checkout-address/checkout-address.component.html
@@ -4,7 +4,7 @@
             (click)="modalService.open(modalID)"
             *ngIf="!isAnon && existingAddresses && existingAddresses.Items.length > 0">Select a saved address</button>
     <shared-address-form [existingAddress]="selectedAddress"
-                         (formSubmitted)="saveAddress($event)"
+                         (formSubmitted)="saveAddress($event.address, $event.formDirty)"
                          btnText="Save and Continue"></shared-address-form>
   </div>
 </div>

--- a/src/UI/Buyer/src/app/checkout/containers/checkout-address/checkout-address.component.spec.ts
+++ b/src/UI/Buyer/src/app/checkout/containers/checkout-address/checkout-address.component.spec.ts
@@ -4,7 +4,11 @@ import { CheckoutAddressComponent } from '@app-buyer/checkout/containers/checkou
 import { ReactiveFormsModule } from '@angular/forms';
 import { AddressFormComponent } from '@app-buyer/shared/components/address-form/address-form.component';
 import { of, BehaviorSubject, Subject } from 'rxjs';
-import { OcMeService, OcOrderService } from '@ordercloud/angular-sdk';
+import {
+  OcMeService,
+  OcOrderService,
+  BuyerAddress,
+} from '@ordercloud/angular-sdk';
 import {
   AppStateService,
   AppFormErrorService,

--- a/src/UI/Buyer/src/app/checkout/containers/checkout-address/checkout-address.component.spec.ts
+++ b/src/UI/Buyer/src/app/checkout/containers/checkout-address/checkout-address.component.spec.ts
@@ -4,11 +4,7 @@ import { CheckoutAddressComponent } from '@app-buyer/checkout/containers/checkou
 import { ReactiveFormsModule } from '@angular/forms';
 import { AddressFormComponent } from '@app-buyer/shared/components/address-form/address-form.component';
 import { of, BehaviorSubject, Subject } from 'rxjs';
-import {
-  OcMeService,
-  OcOrderService,
-  BuyerAddress,
-} from '@ordercloud/angular-sdk';
+import { OcMeService, OcOrderService } from '@ordercloud/angular-sdk';
 import {
   AppStateService,
   AppFormErrorService,
@@ -17,6 +13,7 @@ import {
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { AppGeographyService } from '@app-buyer/shared/services/geography/geography.service';
 import { CheckoutSectionBaseComponent } from '@app-buyer/checkout/components/checkout-section-base/checkout-section-base.component';
+import { ToastrService } from 'ngx-toastr';
 
 describe('CheckoutAddressComponent', () => {
   let component: CheckoutAddressComponent;
@@ -59,6 +56,8 @@ describe('CheckoutAddressComponent', () => {
     lineItemSubject: new BehaviorSubject(mockLineItems),
   };
 
+  const toastrService = { error: jasmine.createSpy('error') };
+
   const modalService = {
     open: jasmine.createSpy('open'),
     close: jasmine.createSpy('close'),
@@ -79,6 +78,7 @@ describe('CheckoutAddressComponent', () => {
         { provide: OcMeService, useValue: meService },
         { provide: OcOrderService, useValue: orderService },
         { provide: AppStateService, useValue: appStateService },
+        { provide: ToastrService, useValue: toastrService },
         AppGeographyService,
       ],
       schemas: [NO_ERRORS_SCHEMA], // Ignore template errors: remove if tests are added to test template
@@ -171,23 +171,23 @@ describe('CheckoutAddressComponent', () => {
     it('should set one time address if user is anon', () => {
       component.isAnon = true;
       component.addressType = 'Shipping';
-      component.saveAddress({ ID: 'mockShippingAddress' });
+      component.saveAddress({ ID: 'mockShippingAddress' }, false);
       expect(component['setOneTimeAddress']).toHaveBeenCalledWith({
         ID: 'mockShippingAddress',
       });
     });
-    it('should set one time address if there is no address.ID', () => {
+    it('should set one time address if the form is dirty', () => {
       component.isAnon = false;
       component.addressType = 'Shipping';
-      component.saveAddress({ Street1: 'MyOneTimeAddresss' });
+      component.saveAddress({ Street1: 'MyOneTimeAddresss' }, true);
       expect(component['setOneTimeAddress']).toHaveBeenCalledWith({
         Street1: 'MyOneTimeAddresss',
       });
     });
-    it('should set saved address if user is profiled and address.ID is defined', () => {
+    it('should set saved address if user is profiled and form is not dirty', () => {
       expect((component.isAnon = false));
       component.addressType = 'Shipping';
-      component.saveAddress({ ID: 'MyOneTimeAddresss' });
+      component.saveAddress({ ID: 'MyOneTimeAddresss' }, false);
       expect(component['setOneTimeAddress']).not.toHaveBeenCalled();
       expect(component['setSavedAddress']).toHaveBeenCalledWith({
         ID: 'MyOneTimeAddresss',
@@ -195,7 +195,7 @@ describe('CheckoutAddressComponent', () => {
     });
     it('should set new address on line item if addressType is shipping', () => {
       component.addressType = 'Shipping';
-      component.saveAddress({ ID: 'MyOneTimeAddresss' });
+      component.saveAddress({ ID: 'MyOneTimeAddresss' }, true);
       expect(component.lineItems.Items[0].ShippingAddress).toEqual({
         ID: 'MyOneTimeAddresss',
       });
@@ -203,7 +203,7 @@ describe('CheckoutAddressComponent', () => {
     it('should set new order as the order', () => {
       spyOn(appStateService.orderSubject, 'next');
       component.addressType = 'Shipping';
-      component.saveAddress({ ID: 'MyOneTimeAddresss' });
+      component.saveAddress({ ID: 'MyOneTimeAddresss' }, false);
       expect(component.order).toEqual({ ID: 'NewOrderWhoDis' });
       expect(appStateService.orderSubject.next).toHaveBeenCalledWith({
         ID: 'NewOrderWhoDis',
@@ -212,7 +212,7 @@ describe('CheckoutAddressComponent', () => {
     it('should emit continue event', () => {
       spyOn(component.continue, 'emit');
       component.addressType = 'Shipping';
-      component.saveAddress({ ID: 'MyOneTimeAddresss' });
+      component.saveAddress({ ID: 'MyOneTimeAddresss' }, false);
       expect(component.continue.emit).toHaveBeenCalled();
     });
   });

--- a/src/UI/Buyer/src/app/checkout/containers/checkout-address/checkout-address.component.ts
+++ b/src/UI/Buyer/src/app/checkout/containers/checkout-address/checkout-address.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { CheckoutSectionBaseComponent } from '@app-buyer/checkout/components/checkout-section-base/checkout-section-base.component';
-import { forkJoin, Observable } from 'rxjs';
+import { Observable } from 'rxjs';
 import {
   OcMeService,
   ListBuyerAddress,
@@ -8,6 +8,7 @@ import {
   Order,
   BuyerAddress,
   ListLineItem,
+  Address,
 } from '@ordercloud/angular-sdk';
 import { AppStateService, ModalService } from '@app-buyer/shared';
 import { filter } from 'rxjs/operators';
@@ -91,14 +92,12 @@ export class CheckoutAddressComponent extends CheckoutSectionBaseComponent
     this.modalService.close(this.modalID);
   }
 
-  saveAddress(address) {
-    const queue = [];
-    if (this.isAnon || !address.ID) {
-      queue.push(this.setOneTimeAddress(address));
-    } else {
-      queue.push(this.setSavedAddress(address));
+  saveAddress(address: Address, formDirty: boolean) {
+    let request = this.setSavedAddress(address);
+    if (this.isAnon || formDirty) {
+      request = this.setOneTimeAddress(address);
     }
-    return forkJoin(queue).subscribe(([order]) => {
+    request.subscribe((order) => {
       if (this.addressType === 'Shipping') {
         this.lineItems.Items[0].ShippingAddress = address;
         this.appStateService.lineItemSubject.next(this.lineItems);

--- a/src/UI/Buyer/src/app/product/components/additional-image-gallery/additional-image-gallery.component.ts
+++ b/src/UI/Buyer/src/app/product/components/additional-image-gallery/additional-image-gallery.component.ts
@@ -13,7 +13,7 @@ export class AdditionalImageGalleryComponent implements OnInit, OnDestroy {
   private readonly gallerySize = 5;
   private alive = true;
 
-  @Input() imgUrls: string[] = [];
+  @Input() imgUrls: string[];
   selectedIndex = 0;
   startIndex = 0;
   endIndex = this.gallerySize - 1;
@@ -25,6 +25,7 @@ export class AdditionalImageGalleryComponent implements OnInit, OnDestroy {
     this.isResponsiveView = window.innerWidth > 900;
   }
   ngOnInit() {
+    this.imgUrls = this.imgUrls || [];
     fromEvent(window, 'resize')
       .pipe(
         // only subscribe to event while directive

--- a/src/UI/Buyer/src/app/product/containers/product-list/product-list.component.ts
+++ b/src/UI/Buyer/src/app/product/containers/product-list/product-list.component.ts
@@ -190,6 +190,9 @@ export class ProductListComponent implements OnInit {
 
     const recursiveBuild = (id) => {
       const cat = this.categories.Items.find((c) => c.ID === id);
+      if (!cat) {
+        return crumbs;
+      }
       crumbs.unshift(cat);
       if (!cat.ParentID) {
         return crumbs;

--- a/src/UI/Buyer/src/app/profile/containers/address-list/address-list.component.html
+++ b/src/UI/Buyer/src/app/profile/containers/address-list/address-list.component.html
@@ -1,7 +1,9 @@
 <h1 class="page-heading border-bottom pb-3">Addresses</h1>
 <div class="mb-3 justify-content-end no-gutters float-right">
   <button (click)="showAddAddress()"
-          class="btn btn-primary"><fa-icon [icon]="faPlus"></fa-icon> Add an Address</button>
+          class="btn btn-primary">
+    <fa-icon [icon]="faPlus"></fa-icon> Add an Address
+  </button>
 </div>
 <shared-generic-browse [items]="addresses?.Items"
                        [meta]="addresses?.Meta"
@@ -23,7 +25,7 @@
 </shared-generic-browse>
 <shared-modal id="{{ modalID }}"
               modalTitle="{{ currentAddress ? 'Edit' : 'Add'}} Address">
-  <shared-address-form (formSubmitted)="addressFormSubmitted($event)"
+  <shared-address-form (formSubmitted)="addressFormSubmitted($event.address)"
                        [existingAddress]="currentAddress"
                        [btnText]="currentAddress ? 'Save Changes' : 'Create Address'"></shared-address-form>
 </shared-modal>

--- a/src/UI/Buyer/src/app/shared/components/address-form/address-form.component.spec.ts
+++ b/src/UI/Buyer/src/app/shared/components/address-form/address-form.component.spec.ts
@@ -7,7 +7,7 @@ import { of } from 'rxjs';
 import { OcMeService } from '@ordercloud/angular-sdk';
 import { AppFormErrorService } from '@app-buyer/shared';
 
-describe('AddressFormComponent', () => {
+fdescribe('AddressFormComponent', () => {
   let component: AddressFormComponent;
   let fixture: ComponentFixture<AddressFormComponent>;
   const meService = {
@@ -88,16 +88,19 @@ describe('AddressFormComponent', () => {
     it('should emit formSubmitted event', () => {
       component['onSubmit']();
       expect(component.formSubmitted.emit).toHaveBeenCalledWith({
-        ID: '',
-        FirstName: 'Crhistian',
-        LastName: 'Ramirez',
-        Street1: '404 5th st sw',
-        Street2: '',
-        City: 'Minneapolis',
-        State: 'MN',
-        Zip: '56001',
-        Phone: '555-555-5555',
-        Country: 'US',
+        address: {
+          ID: '',
+          FirstName: 'Crhistian',
+          LastName: 'Ramirez',
+          Street1: '404 5th st sw',
+          Street2: '',
+          City: 'Minneapolis',
+          State: 'MN',
+          Zip: '56001',
+          Phone: '555-555-5555',
+          Country: 'US',
+        },
+        formDirty: component.addressForm.dirty,
       });
     });
   });

--- a/src/UI/Buyer/src/app/shared/components/address-form/address-form.component.ts
+++ b/src/UI/Buyer/src/app/shared/components/address-form/address-form.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 
 // 3rd party
-import { BuyerAddress } from '@ordercloud/angular-sdk';
+import { BuyerAddress, Address } from '@ordercloud/angular-sdk';
 import { AppGeographyService } from '@app-buyer/shared/services/geography/geography.service';
 import { AppFormErrorService } from '@app-buyer/shared/services/form-error/form-error.service';
 
@@ -14,7 +14,8 @@ import { AppFormErrorService } from '@app-buyer/shared/services/form-error/form-
 export class AddressFormComponent implements OnInit {
   private _existingAddress: BuyerAddress;
   @Input() btnText: string;
-  @Output() formSubmitted = new EventEmitter();
+  @Output()
+  formSubmitted = new EventEmitter<{ address: Address; formDirty: boolean }>();
   stateOptions: string[];
   countryOptions: { label: string; abbreviation: string }[];
   addressForm: FormGroup;
@@ -36,6 +37,7 @@ export class AddressFormComponent implements OnInit {
   set existingAddress(address: BuyerAddress) {
     this._existingAddress = address || {};
     this.setForm();
+    this.addressForm.markAsPristine();
   }
 
   setForm() {
@@ -57,7 +59,10 @@ export class AddressFormComponent implements OnInit {
     if (this.addressForm.status === 'INVALID') {
       return this.formErrorService.displayFormErrors(this.addressForm);
     }
-    this.formSubmitted.emit(this.addressForm.value);
+    this.formSubmitted.emit({
+      address: this.addressForm.value,
+      formDirty: this.addressForm.dirty,
+    });
   }
 
   // control display of error messages


### PR DESCRIPTION
## Description

Four bug fixes.
- Product details page broke if product.xp = null.
- Category breadcrumbs broke if category had parentID but parent was unassigned. 
- If user selected a saved address and then edited it, those changes were not saved to the order.
- If an address was saved to an order and then unassigned in admin, the error message was confusing.

For Reference #96 #218 #210

## Type of change


- [x ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x ] I have added tests that prove my fix is effective or that my feature works
- [x ] New and existing unit tests pass locally with my changes
- [ ] I have updated the acceptance criteria on the task so that it can be tested
- [ ] I have verified my contribution works and looks well in Firefox, Safari and Internet Explorer
