### PR TITLE
only show gallery container if there is more than one image

### DIFF
--- a/src/UI/Buyer/src/app/product/components/additional-image-gallery/additional-image-gallery.component.html
+++ b/src/UI/Buyer/src/app/product/components/additional-image-gallery/additional-image-gallery.component.html
@@ -9,7 +9,7 @@
          [maxZoomLevel]=".6">
   </div>
   <div>
-    <div class="gallery-container row">
+    <div class="gallery-container row" *ngIf="imgUrls.length > 1">
       <div class="col carousel-arrow"
            (click)="backward(imageWrapper)">
         <fa-icon [icon]="faAngleLeft"></fa-icon>


### PR DESCRIPTION
## Description
Doesn't make sense to show this when there's only one image
<!--  
- Summary of the change and which issue is fixed.
- Relevant motivation and context.
- List any dependencies that are required for this change.
-->

For Reference # (issue)

## Type of change

<!-- Please delete options that are not relevant -->

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (change/optimize code without changing external behavior)
- [ ] This change requires a documentation update

## Checklist:

- [ x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [ ] I have updated the acceptance criteria on the task so that it can be tested
- [ ] I have verified my contribution works and looks well in Firefox, Safari and Internet Explorer
