### PR TITLE
Use shipping as billing

### DIFF
--- a/src/UI/Buyer/src/app/checkout/containers/checkout-address/checkout-address.component.html
+++ b/src/UI/Buyer/src/app/checkout/containers/checkout-address/checkout-address.component.html
@@ -1,6 +1,9 @@
 <button class="btn btn-secondary mb-3"
         (click)="modalService.open(modalID)"
         *ngIf="!isAnon && existingAddresses && existingAddresses.Items.length > 0">Select a saved address</button>
+<button *ngIf="addressType === 'Billing'"
+        class="btn btn-secondary mb-3 ml-2"
+        (click)="useShippingAsBilling()">Use Shipping Address</button>
 <shared-address-form [existingAddress]="selectedAddress"
                      (formSubmitted)="saveAddress($event.address, $event.formDirty)"
                      btnText="Save and Continue"></shared-address-form>

--- a/src/UI/Buyer/src/app/checkout/containers/checkout-address/checkout-address.component.spec.ts
+++ b/src/UI/Buyer/src/app/checkout/containers/checkout-address/checkout-address.component.spec.ts
@@ -224,7 +224,7 @@ describe('CheckoutAddressComponent', () => {
       expect(orderService.SetBillingAddress).toHaveBeenCalledWith(
         'outgoing',
         component.order.ID,
-        { ID: 'MockOneTimeAddress' }
+        { ID: null }
       );
     });
     it('should call orderService.SetShippingAddress if addressType is Shipping', () => {
@@ -233,7 +233,7 @@ describe('CheckoutAddressComponent', () => {
       expect(orderService.SetShippingAddress).toHaveBeenCalledWith(
         'outgoing',
         component.order.ID,
-        { ID: 'MockOneTimeAddress' }
+        { ID: null }
       );
     });
   });
@@ -272,6 +272,26 @@ describe('CheckoutAddressComponent', () => {
     it('should do nothing when the wrong modal id is emitted', () => {
       onCloseSubject.next('wrong ID');
       expect(component.updateRequestOptions).not.toHaveBeenCalled();
+    });
+  });
+  describe('useShippingAsBilling', () => {
+    beforeEach(() => {
+      component.usingShippingAsBilling = false;
+      component.selectedAddress = null;
+    });
+    it('should do nothing when address type is Shipping', () => {
+      component.addressType = 'Shipping';
+      component.useShippingAsBilling();
+      expect(component.usingShippingAsBilling).toEqual(false);
+      expect(component.selectedAddress).toEqual(null);
+    });
+    it('should set selected Address', () => {
+      component.addressType = 'Billing';
+      component.useShippingAsBilling();
+      expect(component.usingShippingAsBilling).toEqual(true);
+      expect(component.selectedAddress).toEqual(
+        component.lineItems.Items[0].ShippingAddress
+      );
     });
   });
 });

--- a/src/UI/Buyer/src/app/checkout/containers/checkout-address/checkout-address.component.ts
+++ b/src/UI/Buyer/src/app/checkout/containers/checkout-address/checkout-address.component.ts
@@ -108,7 +108,6 @@ export class CheckoutAddressComponent extends CheckoutSectionBaseComponent
 
   saveAddress(address: Address, formDirty: boolean) {
     let request = this.setSavedAddress(address);
-    debugger;
     if (
       this.isAnon ||
       formDirty ||


### PR DESCRIPTION
## Description

Adding a button in the billing section that lets you use the shipping address

For Reference #274 

## Type of change

- [x ] New feature (non-breaking change which adds functionality)

## Checklist:

- [x ] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x ] I have added tests that prove my fix is effective or that my feature works
- [x ] New and existing unit tests pass locally with my changes
- [ ] I have updated the acceptance criteria on the task so that it can be tested
- [ ] I have verified my contribution works and looks well in Firefox, Safari and Internet Explorer
