### PR TITLE
Fix for issue 287

### DIFF
--- a/src/UI/Buyer/src/app/checkout/containers/checkout-address/checkout-address.component.ts
+++ b/src/UI/Buyer/src/app/checkout/containers/checkout-address/checkout-address.component.ts
@@ -111,7 +111,8 @@ export class CheckoutAddressComponent extends CheckoutSectionBaseComponent
     if (
       this.isAnon ||
       formDirty ||
-      (this.usingShippingAsBilling && !this.order.ShippingAddressID)
+      (this.usingShippingAsBilling && !this.order.ShippingAddressID) ||
+      (!address.ID || address.ID === '') //If this is not a saved address. Fix for issue 287
     ) {
       request = this.setOneTimeAddress(address);
     }


### PR DESCRIPTION
## Description

When saving billing/shipping address use setOneTimeAddress if the address.ID is null or empty string for cases when user is saving a previously entered one time address without making any chnages to the address

For Reference # 282

## Type of change

<!-- Please delete options that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (change/optimize code without changing external behavior)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the acceptance criteria on the task so that it can be tested
- [ ] I have verified my contribution works and looks well in Firefox, Safari and Internet Explorer
