### PR TITLE
disable order submit on click

### DIFF
--- a/src/UI/Buyer/src/app/checkout/components/checkout-confirm/checkout-confirm.component.html
+++ b/src/UI/Buyer/src/app/checkout/components/checkout-confirm/checkout-confirm.component.html
@@ -32,4 +32,5 @@
   </form>
 </div>
 <button class="btn btn-primary mt-4"
-        (click)="saveComments()">Confirm Order</button>
+        [disabled]="isSubmittingOrder"
+        (click)="saveCommentsAndSubmitOrder()">Submit Order</button>

--- a/src/UI/Buyer/src/app/checkout/components/checkout-confirm/checkout-confirm.component.spec.ts
+++ b/src/UI/Buyer/src/app/checkout/components/checkout-confirm/checkout-confirm.component.spec.ts
@@ -71,7 +71,7 @@ describe('CheckoutConfirmComponent', () => {
       spyOn(appStateService.orderSubject, 'next');
       spyOn(component.continue, 'emit');
       component.form.setValue({ comments: 'comment' });
-      component.saveComments();
+      component.saveCommentsAndSubmitOrder();
       expect(orderService.Patch).toHaveBeenCalledWith(
         'outgoing',
         mockOrder.ID,

--- a/src/UI/Buyer/src/app/checkout/components/checkout-confirm/checkout-confirm.component.ts
+++ b/src/UI/Buyer/src/app/checkout/components/checkout-confirm/checkout-confirm.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Inject } from '@angular/core';
+import { Component, OnInit, Inject, Input } from '@angular/core';
 import { CheckoutSectionBaseComponent } from '@app-buyer/checkout/components/checkout-section-base/checkout-section-base.component';
 import { AppStateService, AppLineItemService } from '@app-buyer/shared';
 import {
@@ -26,6 +26,7 @@ export class CheckoutConfirmComponent extends CheckoutSectionBaseComponent
   order: Order;
   payments$: Observable<ListPayment>;
   lineItems$: Observable<ListLineItem>;
+  @Input() isSubmittingOrder: boolean;
 
   constructor(
     private appStateService: AppStateService,
@@ -50,7 +51,11 @@ export class CheckoutConfirmComponent extends CheckoutSectionBaseComponent
     this.lineItems$ = this.appLineItemService.listAll(this.order.ID);
   }
 
-  saveComments() {
+  saveCommentsAndSubmitOrder() {
+    if (this.isSubmittingOrder) {
+      return;
+    }
+    this.isSubmittingOrder = true;
     this.ocOrderService
       .Patch('outgoing', this.order.ID, {
         Comments: this.form.get('comments').value,

--- a/src/UI/Buyer/src/app/checkout/containers/checkout/checkout.component.html
+++ b/src/UI/Buyer/src/app/checkout/containers/checkout/checkout.component.html
@@ -79,7 +79,8 @@
               <a class="link-text"> Confirm </a>
             </ng-template>
             <ng-template ngbPanelContent>
-              <checkout-confirm (continue)="confirmOrder()"></checkout-confirm>
+              <checkout-confirm (continue)="submitOrder()"
+                                [isSubmittingOrder]="isSubmittingOrder"></checkout-confirm>
             </ng-template>
           </ngb-panel>
         </ngb-accordion>

--- a/src/UI/Buyer/src/app/checkout/containers/checkout/checkout.component.spec.ts
+++ b/src/UI/Buyer/src/app/checkout/containers/checkout/checkout.component.spec.ts
@@ -13,6 +13,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { of, BehaviorSubject } from 'rxjs';
 import { OcOrderService, OcPaymentService } from '@ordercloud/angular-sdk';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { AppErrorHandler } from '@app-buyer/config/error-handling.config';
 
 describe('CheckoutComponent', () => {
   let component: CheckoutComponent;
@@ -33,12 +34,17 @@ describe('CheckoutComponent', () => {
     resetUser: jasmine.createSpy('restUser').and.returnValue(null),
   };
 
+  const appErrorHandler = {
+    displayError: jasmine.createSpy('displayError'),
+  };
+
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [CheckoutComponent, NgbAccordion, NgbPanel],
       imports: [FontAwesomeModule, ReactiveFormsModule, RouterTestingModule],
       providers: [
         NgbAccordionConfig,
+        { provide: AppErrorHandler, usevalue: appErrorHandler },
         { provide: AppStateService, useValue: appStateService },
         { provide: OcOrderService, useValue: orderService },
         { provide: OcPaymentService, useValue: paymentService },
@@ -147,9 +153,9 @@ describe('CheckoutComponent', () => {
     });
   });
 
-  describe('confirmOrder()', () => {
+  describe('submitOrder()', () => {
     it('should call necessary services', () => {
-      component.confirmOrder();
+      component.submitOrder();
       expect(orderService.Submit).toHaveBeenCalled();
       expect(baseResolveService.resetUser).toHaveBeenCalled();
     });


### PR DESCRIPTION
also rename confirm order to order submit, conveys intent a bit better

## Description
this ensures a user can't accidentally double click and call order submit twice

## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)

## Checklist:
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [ ] I have updated the acceptance criteria on the task so that it can be tested
- [ x] I have verified my contribution works and looks well in Firefox, Safari and Internet Explorer
