### PR TITLE
fix: popover on mobile showing error #291

### DIFF
--- a/src/UI/Buyer/src/app/layout/header/header.component.html
+++ b/src/UI/Buyer/src/app/layout/header/header.component.html
@@ -89,7 +89,7 @@
            ngbPopover="Item(s) Added to Cart"
            placement="bottom"
            triggers="manual"
-           #desktopPopover="ngbPopover">
+           #addtocartPopover="ngbPopover">
           <span class="d-none d-lg-inline">Cart </span>
           <fa-layers class="fa-fw">
             <fa-icon [icon]="faShoppingCart"></fa-icon>

--- a/src/UI/Buyer/src/app/layout/header/header.component.spec.ts
+++ b/src/UI/Buyer/src/app/layout/header/header.component.spec.ts
@@ -1,22 +1,16 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  async,
+  ComponentFixture,
+  TestBed,
+  fakeAsync,
+  tick,
+} from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { Router, ActivatedRoute } from '@angular/router';
 import { HttpClientModule } from '@angular/common/http';
 
 import { HeaderComponent } from '@app-buyer/layout/header/header.component';
-import {
-  AppStateService,
-  BaseResolveService,
-  AppLineItemService,
-} from '@app-buyer/shared';
-import {
-  OcTokenService,
-  OcAuthService,
-  OcMeService,
-  OcLineItemService,
-  OcSupplierService,
-  OcOrderService,
-} from '@ordercloud/angular-sdk';
+import { AppStateService, BaseResolveService } from '@app-buyer/shared';
 
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { NgbPopoverModule, NgbPopoverConfig } from '@ng-bootstrap/ng-bootstrap';
@@ -96,6 +90,17 @@ describe('HeaderComponent', () => {
     });
     it('should call buildAddToCartListener', () => {
       expect(component.buildAddToCartListener).toHaveBeenCalled();
+    });
+  });
+
+  describe('buildAddToCartListener', () => {
+    beforeEach(() => {
+      spyOn(component.popover, 'open');
+      spyOn(component.popover, 'close');
+    });
+    it('should set correct popover message', () => {
+      appStateService.addToCartSubject.next({ quantity: 4 });
+      expect(component.popover.ngbPopover).toBe('4 Item(s) Added to Cart');
     });
   });
 });

--- a/src/UI/Buyer/src/app/layout/header/header.component.ts
+++ b/src/UI/Buyer/src/app/layout/header/header.component.ts
@@ -35,10 +35,8 @@ export class HeaderComponent implements OnInit, OnDestroy {
   currentOrder: Order;
   alive = true;
   addToCartQuantity: number;
-  @ViewChild('mobilePopover') public mobilePopover: NgbPopover;
-  @ViewChild('desktopPopover') public desktopPopover: NgbPopover;
+  @ViewChild('addtocartPopover') public popover: NgbPopover;
   @ViewChild(SearchComponent) public search: SearchComponent;
-  //@ViewChild('mobileSearch') public mobileSearch: SearchComponent;
 
   faSearch = faSearch;
   faShoppingCart = faShoppingCart;
@@ -70,20 +68,20 @@ export class HeaderComponent implements OnInit, OnDestroy {
   }
 
   buildAddToCartListener() {
-    let popover;
     this.appStateService.addToCartSubject
       .pipe(
         tap((event: AddToCartEvent) => {
-          popover = this.isMobile() ? this.mobilePopover : this.desktopPopover;
-          popover.close();
-          popover.ngbPopover = `${event.quantity} Item(s) Added to Cart`;
+          this.popover.close();
+          this.popover.ngbPopover = `${event.quantity} Item(s) Added to Cart`;
         }),
         delay(300),
-        tap(() => popover.open()),
+        tap(() => {
+          this.popover.open();
+        }),
         debounceTime(3000)
       )
       .subscribe(() => {
-        popover.close();
+        this.popover.close();
       });
   }
 


### PR DESCRIPTION
## Description

the html had been refactored to only need one popovers but the typescript class was not updated and was referencing a popover that did not exist
For Reference #291

## Type of change
- [ x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [ ] I have updated the acceptance criteria on the task so that it can be tested
- [ ] I have verified my contribution works and looks well in Firefox, Safari and Internet Explorer
